### PR TITLE
feat(discovery): add llms.txt, sitemap, and engine orchestrator

### DIFF
--- a/backend/app/discovery/engine.py
+++ b/backend/app/discovery/engine.py
@@ -1,0 +1,82 @@
+"""Discovery engine orchestrator.
+
+Tries discovery strategies in priority order:
+1. llms.txt (most structured)
+2. sitemap.xml (URL list, less metadata)
+3. Sidebar crawl (last resort, fragile)
+"""
+
+from dataclasses import dataclass, field
+
+import httpx
+
+from app.discovery.llms_txt import DiscoveredPage, fetch_llms_txt
+from app.discovery.sitemap import fetch_sitemap
+
+
+@dataclass
+class DiscoveryResult:
+    """Combined result from all discovery strategies."""
+
+    pages: list[DiscoveredPage] = field(default_factory=list)
+    method: str = "none"
+    raw_llms_txt: str | None = None
+
+
+async def discover(
+    base_url: str,
+    client: httpx.AsyncClient | None = None,
+    path_filter: str = "/docs",
+) -> DiscoveryResult:
+    """Discover all documentation pages on a site.
+
+    Tries strategies in priority order: llms.txt → sitemap → sidebar crawl.
+    Returns as soon as one strategy succeeds.
+
+    Args:
+        base_url: Base URL of the documentation site.
+        client: Optional httpx client (creates one if not provided).
+        path_filter: Path filter for sitemap URLs.
+
+    Returns:
+        DiscoveryResult with discovered pages and method used.
+    """
+    own_client = client is None
+    effective_client = (
+        client
+        if client is not None
+        else httpx.AsyncClient(
+            timeout=httpx.Timeout(30.0),
+            follow_redirects=True,
+            headers={"User-Agent": "minimax-scraper/0.1.0 (documentation archiver)"},
+        )
+    )
+
+    result = DiscoveryResult()
+
+    try:
+        # Strategy 1: llms.txt
+        llms_result = await fetch_llms_txt(base_url, effective_client)
+        if llms_result and llms_result.pages:
+            result.pages = llms_result.pages
+            result.method = "llms_txt"
+            result.raw_llms_txt = llms_result.raw_text
+            return result
+
+        # Strategy 2: sitemap.xml
+        sitemap_result = await fetch_sitemap(base_url, effective_client, path_filter=path_filter)
+        if sitemap_result and sitemap_result.urls:
+            result.pages = [
+                DiscoveredPage(url=u.url, title="", section="") for u in sitemap_result.urls
+            ]
+            result.method = "sitemap"
+            return result
+
+        # Strategy 3: Sidebar crawl (TODO — implement in sidebar.py)
+        # For now, return empty result
+
+    finally:
+        if own_client:
+            await effective_client.aclose()
+
+    return result

--- a/backend/app/discovery/llms_txt.py
+++ b/backend/app/discovery/llms_txt.py
@@ -1,0 +1,137 @@
+"""Parser for the llms.txt documentation index format.
+
+The llms.txt standard (https://llmstxt.org/) provides a machine-readable
+index of documentation pages. Format:
+
+    # Site Name
+    > Site description
+
+    ## Section Name
+    - [Page Title](url): Description
+"""
+
+import re
+from dataclasses import dataclass, field
+from urllib.parse import urlparse
+
+import httpx
+
+
+@dataclass
+class DiscoveredPage:
+    """A page discovered from llms.txt."""
+
+    url: str
+    title: str
+    description: str = ""
+    section: str = ""
+
+
+@dataclass
+class LlmsTxtResult:
+    """Parsed result from an llms.txt file."""
+
+    site_name: str = ""
+    site_description: str = ""
+    pages: list[DiscoveredPage] = field(default_factory=list)
+    raw_text: str = ""
+
+
+# Matches markdown links with optional description: [title](url): description
+_LINK_PATTERN = re.compile(r"-\s*\[([^\]]+)\]\(([^)]+)\)(?:\s*:\s*(.+))?")
+
+
+def parse_llms_txt(text: str, base_url: str = "") -> LlmsTxtResult:
+    """Parse llms.txt content into structured data.
+
+    Args:
+        text: Raw llms.txt content.
+        base_url: Base URL for resolving relative links.
+
+    Returns:
+        LlmsTxtResult with site info and discovered pages.
+    """
+    result = LlmsTxtResult(raw_text=text)
+    current_section = ""
+
+    for line in text.splitlines():
+        line = line.strip()
+
+        # H1: Site name
+        if line.startswith("# ") and not line.startswith("## "):
+            result.site_name = line[2:].strip()
+            continue
+
+        # Blockquote: Site description
+        if line.startswith("> "):
+            desc = line[2:].strip()
+            if result.site_description:
+                result.site_description += " " + desc
+            else:
+                result.site_description = desc
+            continue
+
+        # H2: Section header
+        if line.startswith("## "):
+            current_section = line[3:].strip()
+            continue
+
+        # Link: - [title](url): description
+        match = _LINK_PATTERN.match(line)
+        if match:
+            title = match.group(1).strip()
+            url = match.group(2).strip()
+            description = (match.group(3) or "").strip()
+
+            # Resolve relative URLs
+            if url.startswith("/") and base_url:
+                url = base_url.rstrip("/") + url
+            elif not url.startswith("http") and base_url:
+                url = base_url.rstrip("/") + "/" + url
+            elif not url.startswith("http"):
+                # No base_url and not absolute — skip this broken link
+                continue
+
+            result.pages.append(
+                DiscoveredPage(
+                    url=url,
+                    title=title,
+                    description=description,
+                    section=current_section,
+                )
+            )
+
+    return result
+
+
+async def fetch_llms_txt(base_url: str, client: httpx.AsyncClient) -> LlmsTxtResult | None:
+    """Fetch and parse llms.txt from a documentation site.
+
+    Tries /llms.txt and /docs/llms.txt.
+
+    Returns:
+        Parsed result, or None if not found.
+    """
+    base = base_url.rstrip("/")
+    candidates = [
+        f"{base}/llms.txt",
+        f"{base}/docs/llms.txt",
+        f"{base}/llms-full.txt",
+    ]
+
+    for url in candidates:
+        try:
+            response = await client.get(url, follow_redirects=True)
+            if response.status_code == 200 and len(response.text) > 50:
+                # Reject HTML error pages masquerading as llms.txt
+                if response.text.lstrip().startswith("<"):
+                    continue
+
+                # Extract base URL for resolving relative links
+                parsed = urlparse(base)
+                site_root = f"{parsed.scheme}://{parsed.netloc}"
+                return parse_llms_txt(response.text, base_url=site_root)
+        except httpx.HTTPError:
+            continue
+
+    return None

--- a/backend/app/discovery/sitemap.py
+++ b/backend/app/discovery/sitemap.py
@@ -1,0 +1,149 @@
+"""Parser for sitemap.xml documentation indexes."""
+
+from dataclasses import dataclass, field
+from urllib.parse import urlparse
+
+import httpx
+from defusedxml import ElementTree
+
+# Cap to prevent memory issues with massive sitemaps
+_MAX_URLS = 10_000
+
+
+@dataclass
+class SitemapUrl:
+    """A URL discovered from sitemap.xml."""
+
+    url: str
+    lastmod: str | None = None
+
+
+@dataclass
+class SitemapResult:
+    """Parsed result from sitemap.xml."""
+
+    urls: list[SitemapUrl] = field(default_factory=list)
+    is_index: bool = False
+
+
+def parse_sitemap_xml(xml_text: str, path_filter: str = "/docs") -> SitemapResult:
+    """Parse sitemap.xml content, filtering to documentation paths.
+
+    Args:
+        xml_text: Raw XML content.
+        path_filter: Only include URLs whose path starts with this prefix.
+                     Empty string means include all.
+
+    Returns:
+        SitemapResult with discovered URLs.
+    """
+    result = SitemapResult()
+
+    try:
+        root = ElementTree.fromstring(xml_text)
+    except ElementTree.ParseError:
+        return result
+
+    # Handle namespace (sitemaps use xmlns)
+    ns = ""
+    if root.tag.startswith("{"):
+        ns = root.tag.split("}")[0] + "}"
+
+    # Check if this is a sitemap index (contains other sitemaps)
+    sitemap_tags = root.findall(f"{ns}sitemap")
+    if sitemap_tags:
+        result.is_index = True
+        for sitemap in sitemap_tags:
+            loc = sitemap.find(f"{ns}loc")
+            if loc is not None and loc.text:
+                result.urls.append(SitemapUrl(url=loc.text.strip()))
+        return result
+
+    # Regular sitemap — extract URLs
+    for url_elem in root.findall(f"{ns}url"):
+        if len(result.urls) >= _MAX_URLS:
+            break
+
+        loc = url_elem.find(f"{ns}loc")
+        lastmod = url_elem.find(f"{ns}lastmod")
+
+        if loc is not None and loc.text:
+            url = loc.text.strip()
+            parsed = urlparse(url)
+
+            # Apply path filter (segment-aware: /docs matches /docs/foo but not /redocs)
+            if path_filter and not (
+                parsed.path == path_filter
+                or parsed.path.startswith(path_filter + "/")
+                or parsed.path.startswith(path_filter + "?")
+            ):
+                continue
+
+            result.urls.append(
+                SitemapUrl(
+                    url=url,
+                    lastmod=lastmod.text.strip() if lastmod is not None and lastmod.text else None,
+                )
+            )
+
+    return result
+
+
+async def fetch_sitemap(
+    base_url: str,
+    client: httpx.AsyncClient,
+    path_filter: str = "/docs",
+    _depth: int = 0,
+) -> SitemapResult | None:
+    """Fetch and parse sitemap.xml from a site.
+
+    Handles sitemap indexes by recursively fetching sub-sitemaps (max 2 levels).
+
+    Returns:
+        Parsed result, or None if not found.
+    """
+    if _depth > 2:
+        return None
+
+    base = base_url.rstrip("/")
+    candidates = [
+        f"{base}/sitemap.xml",
+        f"{base}/docs/sitemap.xml",
+    ]
+
+    for url in candidates:
+        try:
+            response = await client.get(url, follow_redirects=True)
+            content_type = response.headers.get("content-type", "")
+            is_xml = "xml" in content_type or response.text.lstrip().startswith("<?xml")
+
+            if response.status_code == 200 and is_xml:
+                parsed = parse_sitemap_xml(response.text, path_filter=path_filter)
+
+                # If this is a sitemap index, recursively fetch sub-sitemaps
+                if parsed.is_index:
+                    merged = SitemapResult()
+                    for sub_sitemap in parsed.urls:
+                        try:
+                            sub_response = await client.get(sub_sitemap.url, follow_redirects=True)
+                            sub_ct = sub_response.headers.get("content-type", "")
+                            sub_is_xml = "xml" in sub_ct or sub_response.text.lstrip().startswith(
+                                "<?xml"
+                            )
+                            if sub_response.status_code == 200 and sub_is_xml:
+                                sub_parsed = parse_sitemap_xml(
+                                    sub_response.text, path_filter=path_filter
+                                )
+                                merged.urls.extend(sub_parsed.urls)
+                                if len(merged.urls) >= _MAX_URLS:
+                                    merged.urls = merged.urls[:_MAX_URLS]
+                                    break
+                        except httpx.HTTPError:
+                            continue
+                    return merged if merged.urls else None
+
+                return parsed if parsed.urls else None
+        except httpx.HTTPError:
+            continue
+
+    return None

--- a/backend/tests/fixtures/sample_llms.txt
+++ b/backend/tests/fixtures/sample_llms.txt
@@ -1,0 +1,17 @@
+# MiniMax Platform
+
+> MiniMax AI platform documentation for developers.
+
+## Getting Started
+
+- [Models Introduction](https://platform.minimax.io/docs/guides/models-intro): Overview of available AI models
+- [Quickstart Guide](/docs/guides/quickstart): Get up and running in 5 minutes
+
+## API Reference
+
+- [Text Chat](https://platform.minimax.io/docs/api-reference/text/chat): Text generation chat API
+- [Video Generation](https://platform.minimax.io/docs/api-reference/video/text-to-video): Generate videos from text prompts
+
+## Solutions
+
+- [Audiobook Workshop](https://platform.minimax.io/docs/solutions/audiobook): Build audiobooks with AI voices

--- a/backend/tests/fixtures/sample_sitemap.xml
+++ b/backend/tests/fixtures/sample_sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/docs/getting-started</loc>
+    <lastmod>2025-01-15</lastmod>
+  </url>
+  <url>
+    <loc>https://example.com/docs/api-reference</loc>
+    <lastmod>2025-02-01</lastmod>
+  </url>
+  <url>
+    <loc>https://example.com/blog/announcement</loc>
+    <lastmod>2025-01-20</lastmod>
+  </url>
+  <url>
+    <loc>https://example.com/docs/guides/quickstart</loc>
+  </url>
+</urlset>

--- a/backend/tests/fixtures/sample_sitemap_index.xml
+++ b/backend/tests/fixtures/sample_sitemap_index.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://example.com/sitemap-docs.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://example.com/sitemap-blog.xml</loc>
+  </sitemap>
+</sitemapindex>

--- a/backend/tests/test_discovery/test_engine.py
+++ b/backend/tests/test_discovery/test_engine.py
@@ -1,0 +1,127 @@
+"""Tests for discovery engine orchestrator."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from app.discovery.engine import discover
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+
+class TestDiscover:
+    """Tests for the discover() orchestrator."""
+
+    @pytest.fixture
+    def llms_text(self) -> str:
+        return (FIXTURES / "sample_llms.txt").read_text()
+
+    @pytest.fixture
+    def sitemap_xml(self) -> str:
+        return (FIXTURES / "sample_sitemap.xml").read_text()
+
+    async def test_prefers_llms_txt(self, llms_text: str, sitemap_xml: str) -> None:
+        """When both llms.txt and sitemap exist, llms.txt wins."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/llms.txt":
+                return httpx.Response(200, text=llms_text)
+            if request.url.path == "/sitemap.xml":
+                return httpx.Response(
+                    200,
+                    text=sitemap_xml,
+                    headers={"content-type": "application/xml"},
+                )
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await discover("https://example.com", client=client)
+
+        assert result.method == "llms_txt"
+        assert len(result.pages) == 5
+        assert result.raw_llms_txt is not None
+
+    async def test_falls_back_to_sitemap(self, sitemap_xml: str) -> None:
+        """When llms.txt is missing, falls back to sitemap."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/sitemap.xml":
+                return httpx.Response(
+                    200,
+                    text=sitemap_xml,
+                    headers={"content-type": "application/xml"},
+                )
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await discover("https://example.com", client=client)
+
+        assert result.method == "sitemap"
+        assert len(result.pages) == 3  # filtered to /docs
+
+    async def test_returns_empty_when_nothing_found(self) -> None:
+        """When no discovery method works, returns empty result."""
+        transport = httpx.MockTransport(lambda req: httpx.Response(404))
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await discover("https://example.com", client=client)
+
+        assert result.method == "none"
+        assert result.pages == []
+
+    async def test_creates_own_client_if_none(self) -> None:
+        """When no client is passed, creates and closes its own."""
+        # Mock both strategies to return nothing — avoids real network calls
+        transport = httpx.MockTransport(lambda req: httpx.Response(404))
+        mock_client = httpx.AsyncClient(transport=transport)
+
+        with patch("app.discovery.engine.httpx.AsyncClient", return_value=mock_client):
+            result = await discover("https://example.com", client=None)
+
+        assert result.method == "none"
+        assert result.pages == []
+
+    async def test_path_filter_passed_to_sitemap(self, sitemap_xml: str) -> None:
+        """Custom path_filter is forwarded to sitemap parser."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/sitemap.xml":
+                return httpx.Response(
+                    200,
+                    text=sitemap_xml,
+                    headers={"content-type": "application/xml"},
+                )
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await discover("https://example.com", client=client, path_filter="/blog")
+
+        assert result.method == "sitemap"
+        assert len(result.pages) == 1
+        assert "blog" in result.pages[0].url
+
+    async def test_llms_txt_with_no_pages_falls_through(self) -> None:
+        """If llms.txt exists but has no links, falls through to sitemap."""
+        llms_no_links = "# Site Name\n> Description only\n"
+        sitemap_xml = (FIXTURES / "sample_sitemap.xml").read_text()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/llms.txt":
+                return httpx.Response(200, text=llms_no_links)
+            if request.url.path == "/sitemap.xml":
+                return httpx.Response(
+                    200,
+                    text=sitemap_xml,
+                    headers={"content-type": "application/xml"},
+                )
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await discover("https://example.com", client=client)
+
+        assert result.method == "sitemap"

--- a/backend/tests/test_discovery/test_llms_txt.py
+++ b/backend/tests/test_discovery/test_llms_txt.py
@@ -1,0 +1,168 @@
+"""Tests for llms.txt parser."""
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from app.discovery.llms_txt import fetch_llms_txt, parse_llms_txt
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+
+class TestParseLlmsTxt:
+    """Tests for parse_llms_txt()."""
+
+    def test_parses_site_name(self) -> None:
+        text = "# MiniMax Platform\n"
+        result = parse_llms_txt(text)
+        assert result.site_name == "MiniMax Platform"
+
+    def test_parses_site_description(self) -> None:
+        text = "# Site\n> A cool site for docs.\n"
+        result = parse_llms_txt(text)
+        assert result.site_description == "A cool site for docs."
+
+    def test_multiline_description(self) -> None:
+        text = "# Site\n> Line one.\n> Line two.\n"
+        result = parse_llms_txt(text)
+        assert result.site_description == "Line one. Line two."
+
+    def test_parses_sections_and_links(self) -> None:
+        result = parse_llms_txt(
+            (FIXTURES / "sample_llms.txt").read_text(),
+            base_url="https://platform.minimax.io",
+        )
+        assert result.site_name == "MiniMax Platform"
+        assert len(result.pages) == 5
+
+        # Check first page
+        assert result.pages[0].title == "Models Introduction"
+        assert result.pages[0].url == "https://platform.minimax.io/docs/guides/models-intro"
+        assert result.pages[0].section == "Getting Started"
+        assert "Overview" in result.pages[0].description
+
+    def test_resolves_relative_urls(self) -> None:
+        result = parse_llms_txt(
+            (FIXTURES / "sample_llms.txt").read_text(),
+            base_url="https://platform.minimax.io",
+        )
+        quickstart = next(p for p in result.pages if "quickstart" in p.url.lower())
+        assert quickstart.url == "https://platform.minimax.io/docs/guides/quickstart"
+
+    def test_preserves_raw_text(self) -> None:
+        text = "# Site\n- [Page](https://example.com): Desc\n"
+        result = parse_llms_txt(text)
+        assert result.raw_text == text
+
+    def test_empty_input(self) -> None:
+        result = parse_llms_txt("")
+        assert result.pages == []
+        assert result.site_name == ""
+
+    def test_no_links(self) -> None:
+        result = parse_llms_txt("# Just a heading\n> Description only\n")
+        assert result.pages == []
+        assert result.site_name == "Just a heading"
+
+    def test_link_without_description(self) -> None:
+        text = "- [Page](https://example.com/page)\n"
+        result = parse_llms_txt(text)
+        assert len(result.pages) == 1
+        assert result.pages[0].description == ""
+
+    def test_bare_relative_url(self) -> None:
+        text = "- [Page](page/foo)\n"
+        result = parse_llms_txt(text, base_url="https://site.com")
+        assert result.pages[0].url == "https://site.com/page/foo"
+
+    def test_bare_relative_url_no_base_url_skipped(self) -> None:
+        """Bare relative URLs without base_url are skipped (no broken URLs)."""
+        text = "- [Page](page/foo)\n"
+        result = parse_llms_txt(text, base_url="")
+        assert result.pages == []
+
+    def test_absolute_url_different_domain_preserved(self) -> None:
+        """Absolute URLs on other domains are kept as-is."""
+        text = "- [Other](https://other.com/docs/page): External\n"
+        result = parse_llms_txt(text, base_url="https://mysite.com")
+        assert result.pages[0].url == "https://other.com/docs/page"
+
+
+class TestFetchLlmsTxt:
+    """Tests for fetch_llms_txt() with mocked HTTP."""
+
+    @pytest.fixture
+    def sample_text(self) -> str:
+        return (FIXTURES / "sample_llms.txt").read_text()
+
+    async def test_returns_none_on_404(self) -> None:
+        transport = httpx.MockTransport(lambda req: httpx.Response(404))
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await fetch_llms_txt("https://example.com", client)
+        assert result is None
+
+    async def test_fetches_from_llms_txt_path(self, sample_text: str) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/llms.txt":
+                return httpx.Response(200, text=sample_text)
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await fetch_llms_txt("https://example.com", client)
+
+        assert result is not None
+        assert result.site_name == "MiniMax Platform"
+        assert len(result.pages) == 5
+
+    async def test_falls_back_to_docs_path(self, sample_text: str) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/docs/llms.txt":
+                return httpx.Response(200, text=sample_text)
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await fetch_llms_txt("https://example.com", client)
+
+        assert result is not None
+        assert len(result.pages) == 5
+
+    async def test_skips_short_responses(self) -> None:
+        transport = httpx.MockTransport(lambda req: httpx.Response(200, text="short"))
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await fetch_llms_txt("https://example.com", client)
+        assert result is None
+
+    async def test_handles_http_error(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("Connection refused")
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await fetch_llms_txt("https://example.com", client)
+        assert result is None
+
+    async def test_rejects_html_error_page(self) -> None:
+        """HTML responses are rejected even if status is 200."""
+        html = "<html><body>404 Not Found</body></html>" + "x" * 50
+        transport = httpx.MockTransport(lambda req: httpx.Response(200, text=html))
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await fetch_llms_txt("https://example.com", client)
+        assert result is None
+
+    async def test_falls_back_to_llms_full_txt(self, sample_text: str) -> None:
+        """Falls back to /llms-full.txt if other paths fail."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/llms-full.txt":
+                return httpx.Response(200, text=sample_text)
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await fetch_llms_txt("https://example.com", client)
+
+        assert result is not None
+        assert len(result.pages) == 5

--- a/backend/tests/test_discovery/test_sitemap.py
+++ b/backend/tests/test_discovery/test_sitemap.py
@@ -1,0 +1,179 @@
+"""Tests for sitemap.xml parser."""
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from app.discovery.sitemap import fetch_sitemap, parse_sitemap_xml
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+
+class TestParseSitemapXml:
+    """Tests for parse_sitemap_xml()."""
+
+    def test_parses_urls_with_docs_filter(self) -> None:
+        xml = (FIXTURES / "sample_sitemap.xml").read_text()
+        result = parse_sitemap_xml(xml, path_filter="/docs")
+        # Should include /docs/* URLs but not /blog/*
+        assert len(result.urls) == 3
+        urls = [u.url for u in result.urls]
+        assert "https://example.com/docs/getting-started" in urls
+        assert "https://example.com/docs/api-reference" in urls
+        assert "https://example.com/docs/guides/quickstart" in urls
+        assert "https://example.com/blog/announcement" not in urls
+
+    def test_parses_lastmod(self) -> None:
+        xml = (FIXTURES / "sample_sitemap.xml").read_text()
+        result = parse_sitemap_xml(xml, path_filter="/docs")
+        getting_started = next(u for u in result.urls if "getting-started" in u.url)
+        assert getting_started.lastmod == "2025-01-15"
+
+    def test_lastmod_none_when_missing(self) -> None:
+        xml = (FIXTURES / "sample_sitemap.xml").read_text()
+        result = parse_sitemap_xml(xml, path_filter="/docs")
+        quickstart = next(u for u in result.urls if "quickstart" in u.url)
+        assert quickstart.lastmod is None
+
+    def test_no_filter_returns_all(self) -> None:
+        xml = (FIXTURES / "sample_sitemap.xml").read_text()
+        result = parse_sitemap_xml(xml, path_filter="")
+        assert len(result.urls) == 4
+
+    def test_sitemap_index(self) -> None:
+        xml = (FIXTURES / "sample_sitemap_index.xml").read_text()
+        result = parse_sitemap_xml(xml)
+        assert result.is_index is True
+        assert len(result.urls) == 2
+        urls = [u.url for u in result.urls]
+        assert "https://example.com/sitemap-docs.xml" in urls
+        assert "https://example.com/sitemap-blog.xml" in urls
+
+    def test_path_filter_segment_aware(self) -> None:
+        """Filter /docs should not match /redocs or /api-docs."""
+        xml = """<?xml version="1.0"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <url><loc>https://example.com/docs/page</loc></url>
+          <url><loc>https://example.com/redocs/page</loc></url>
+          <url><loc>https://example.com/api-docs/page</loc></url>
+        </urlset>"""
+        result = parse_sitemap_xml(xml, path_filter="/docs")
+        assert len(result.urls) == 1
+        assert result.urls[0].url == "https://example.com/docs/page"
+
+    def test_invalid_xml(self) -> None:
+        result = parse_sitemap_xml("not xml at all")
+        assert result.urls == []
+
+    def test_empty_xml(self) -> None:
+        result = parse_sitemap_xml('<?xml version="1.0"?><urlset></urlset>')
+        assert result.urls == []
+
+    def test_no_namespace(self) -> None:
+        xml = """<?xml version="1.0"?>
+        <urlset>
+          <url><loc>https://example.com/docs/page</loc></url>
+        </urlset>"""
+        result = parse_sitemap_xml(xml, path_filter="/docs")
+        assert len(result.urls) == 1
+
+
+class TestFetchSitemap:
+    """Tests for fetch_sitemap() with mocked HTTP."""
+
+    @pytest.fixture
+    def sample_xml(self) -> str:
+        return (FIXTURES / "sample_sitemap.xml").read_text()
+
+    async def test_returns_none_on_404(self) -> None:
+        transport = httpx.MockTransport(lambda req: httpx.Response(404))
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await fetch_sitemap("https://example.com", client)
+        assert result is None
+
+    async def test_fetches_from_sitemap_xml(self, sample_xml: str) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/sitemap.xml":
+                return httpx.Response(
+                    200,
+                    text=sample_xml,
+                    headers={"content-type": "application/xml"},
+                )
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await fetch_sitemap("https://example.com", client)
+
+        assert result is not None
+        assert len(result.urls) == 3  # /docs filter applied
+
+    async def test_falls_back_to_docs_sitemap(self, sample_xml: str) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/docs/sitemap.xml":
+                return httpx.Response(
+                    200,
+                    text=sample_xml,
+                    headers={"content-type": "application/xml"},
+                )
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await fetch_sitemap("https://example.com", client)
+
+        assert result is not None
+
+    async def test_skips_non_xml_content_type(self) -> None:
+        transport = httpx.MockTransport(
+            lambda req: httpx.Response(
+                200,
+                text="<html>not a sitemap</html>",
+                headers={"content-type": "text/html"},
+            )
+        )
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await fetch_sitemap("https://example.com", client)
+        assert result is None
+
+    async def test_handles_http_error(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("Connection refused")
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await fetch_sitemap("https://example.com", client)
+        assert result is None
+
+    async def test_recursive_sitemap_index(self) -> None:
+        """Sitemap indexes are fetched recursively to get actual page URLs."""
+        index_xml = (FIXTURES / "sample_sitemap_index.xml").read_text()
+        page_xml = (FIXTURES / "sample_sitemap.xml").read_text()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = str(request.url.path)
+            if path == "/sitemap.xml":
+                return httpx.Response(
+                    200,
+                    text=index_xml,
+                    headers={"content-type": "application/xml"},
+                )
+            if "sitemap-" in path:
+                return httpx.Response(
+                    200,
+                    text=page_xml,
+                    headers={"content-type": "application/xml"},
+                )
+            return httpx.Response(404)
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            result = await fetch_sitemap("https://example.com", client)
+
+        assert result is not None
+        # Both sub-sitemaps return the same 3 /docs URLs, so we get 6 total
+        assert len(result.urls) == 6
+        # All should be actual page URLs, not XML file URLs
+        for u in result.urls:
+            assert not u.url.endswith(".xml")


### PR DESCRIPTION
## Summary

- Implements the three-strategy discovery cascade: **llms.txt → sitemap.xml → sidebar crawl** (sidebar TBD)
- `llms_txt.py`: Parses the [llms.txt standard](https://llmstxt.org/) with section extraction, relative URL resolution, and HTML error page rejection
- `sitemap.py`: Parses sitemap.xml with defusedxml for security, namespace handling, **recursive sitemap index resolution**, segment-aware path filtering (`/docs` won't match `/redocs`), and a 10k URL cap
- `engine.py`: Orchestrator that tries strategies in priority order and falls back gracefully

## Key Design Decisions

- **Recursive sitemap index handling**: When a sitemap.xml is actually a sitemap index (pointing to sub-sitemaps), we recursively fetch and merge the sub-sitemaps instead of returning XML file URLs as page URLs
- **Segment-aware path filtering**: `/docs` filter matches `/docs/foo` but not `/redocs` or `/api-docs`
- **HTML rejection in llms.txt**: Responses starting with `<` are rejected to avoid parsing CDN/WAF error pages as documentation indexes
- **Bare relative URL safety**: Links like `page/foo` without a `base_url` are skipped rather than producing broken URLs

## Test Plan

- **41 unit tests** covering parsers, HTTP mocking, edge cases, and error handling
- **Live E2E validation**: Tested against `platform.minimax.io` — discovered **156 documentation pages** via llms.txt
- All tests pass: `pytest` (41/41), `mypy --strict` (0 errors), `ruff check + format` (clean)

## 8-Stage Dev Loop Checklist

- [x] 1. Code — Implementation complete
- [x] 2. Iterate — Code review fixes applied (3 critical, 5 warnings addressed)
- [x] 3. Static Test — 41/41 pytest pass
- [x] 4. Deep Static Test — mypy --strict clean
- [x] 5. Check Syntax — ruff check + format clean
- [x] 6. Code Review — Subagent review completed, all critical issues fixed
- [x] 7. E2E — Live test against platform.minimax.io: 156 pages discovered
- [x] 8. Dogfood — Discovery cascade works end-to-end

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)