### PR TITLE
feat(api): REST endpoints and WebSocket for job management

### DIFF
--- a/backend/app/api/browse.py
+++ b/backend/app/api/browse.py
@@ -1,0 +1,108 @@
+"""REST API for browsing scraped files."""
+
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.db import ScrapeJob
+from app.models.schemas import FileTreeNode
+from app.storage.database import get_session
+
+router = APIRouter(prefix="/api/browse", tags=["browse"])
+
+_MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB read limit
+
+
+@router.get("/{job_id}/tree", response_model=list[FileTreeNode])
+async def get_file_tree(
+    job_id: str,
+    session: AsyncSession = Depends(get_session),
+) -> Any:
+    """Get the file tree for a completed job."""
+    job = await session.get(ScrapeJob, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    if not job.output_dir:
+        raise HTTPException(status_code=404, detail="No output directory for this job")
+
+    output_path = Path(job.output_dir)
+    if not output_path.is_dir():
+        raise HTTPException(status_code=404, detail="Output directory not found on disk")
+
+    return _build_tree(output_path, output_path)
+
+
+@router.get("/{job_id}/file")
+async def get_file_content(
+    job_id: str,
+    path: str,
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, str]:
+    """Get raw markdown content for a specific file."""
+    job = await session.get(ScrapeJob, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    if not job.output_dir:
+        raise HTTPException(status_code=404, detail="No output directory for this job")
+
+    output_path = Path(job.output_dir)
+    file_path = (output_path / path).resolve()
+
+    # Path traversal protection
+    if not file_path.is_relative_to(output_path.resolve()):
+        raise HTTPException(status_code=403, detail="Path traversal rejected")
+
+    if not file_path.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+
+    if file_path.stat().st_size > _MAX_FILE_SIZE:
+        raise HTTPException(status_code=413, detail="File too large")
+
+    content = file_path.read_text(encoding="utf-8")
+    return {"path": path, "content": content}
+
+
+def _build_tree(root: Path, current: Path) -> list[FileTreeNode]:
+    """Recursively build a file tree from the filesystem."""
+    nodes: list[FileTreeNode] = []
+    try:
+        entries = sorted(current.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower()))
+    except PermissionError:
+        return nodes
+
+    for entry in entries:
+        # Skip hidden files and metadata
+        if entry.name.startswith(".") or entry.name.startswith("_"):
+            continue
+
+        relative = str(entry.relative_to(root))
+
+        if entry.is_dir():
+            children = _build_tree(root, entry)
+            nodes.append(
+                FileTreeNode(
+                    name=entry.name,
+                    path=relative,
+                    is_dir=True,
+                    children=children,
+                )
+            )
+        elif entry.suffix == ".md":
+            # Estimate word count from file size to avoid reading all files into memory
+            # (~5 chars per word on average for English text)
+            size = entry.stat().st_size
+            word_count = size // 5
+            nodes.append(
+                FileTreeNode(
+                    name=entry.name,
+                    path=relative,
+                    is_dir=False,
+                    word_count=word_count,
+                )
+            )
+
+    return nodes

--- a/backend/app/api/jobs.py
+++ b/backend/app/api/jobs.py
@@ -1,0 +1,244 @@
+"""REST API for scrape job management."""
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.config import settings
+from app.discovery.engine import discover
+from app.models.db import DiscoveredUrl, DiscoveryMethod, JobStatus, Page, PageStatus, ScrapeJob
+from app.models.schemas import PageResponse, ScrapeJobCreate, ScrapeJobResponse
+from app.scraper.engine import ScrapeProgress, scrape
+from app.scraper.fetcher import Fetcher
+from app.storage.database import get_session
+
+router = APIRouter(prefix="/api/jobs", tags=["jobs"])
+
+# Track running tasks so they can be cancelled
+_running_tasks: dict[str, asyncio.Task[None]] = {}
+_MAX_CONCURRENT_JOBS = 10
+
+
+@router.post("", response_model=ScrapeJobResponse, status_code=201)
+async def create_job(
+    body: ScrapeJobCreate,
+    session: AsyncSession = Depends(get_session),
+) -> Any:
+    """Create a new scrape job and start it in the background."""
+    # Prevent unbounded job creation
+    active = sum(1 for t in _running_tasks.values() if not t.done())
+    if active >= _MAX_CONCURRENT_JOBS:
+        raise HTTPException(status_code=429, detail="Too many active jobs")
+
+    job = ScrapeJob(url=str(body.url), status=JobStatus.PENDING)
+    session.add(job)
+    await session.commit()
+    await session.refresh(job)
+
+    # Launch the scrape pipeline in the background
+    task = asyncio.create_task(_run_job(job.id, str(body.url), body.rate_limit))
+    _running_tasks[job.id] = task
+
+    return job
+
+
+@router.get("", response_model=list[ScrapeJobResponse])
+async def list_jobs(
+    session: AsyncSession = Depends(get_session),
+) -> Any:
+    """List all scrape jobs, newest first."""
+    result = await session.execute(select(ScrapeJob).order_by(ScrapeJob.created_at.desc()))
+    return list(result.scalars().all())
+
+
+@router.get("/{job_id}", response_model=ScrapeJobResponse)
+async def get_job(
+    job_id: str,
+    session: AsyncSession = Depends(get_session),
+) -> Any:
+    """Get details for a specific job."""
+    job = await session.get(ScrapeJob, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return job
+
+
+@router.get("/{job_id}/pages", response_model=list[PageResponse])
+async def get_job_pages(
+    job_id: str,
+    session: AsyncSession = Depends(get_session),
+) -> Any:
+    """Get all pages for a specific job."""
+    job = await session.get(ScrapeJob, job_id, options=[selectinload(ScrapeJob.pages)])
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return job.pages
+
+
+@router.delete("/{job_id}", status_code=204)
+async def cancel_job(
+    job_id: str,
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    """Cancel a running scrape job."""
+    job = await session.get(ScrapeJob, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    if job.status in (JobStatus.COMPLETE, JobStatus.FAILED, JobStatus.CANCELLED):
+        raise HTTPException(status_code=409, detail=f"Job already {job.status.value}")
+
+    # Cancel the background task if running
+    task = _running_tasks.pop(job_id, None)
+    if task and not task.done():
+        task.cancel()
+
+    job.status = JobStatus.CANCELLED
+    await session.commit()
+
+
+async def _run_job(job_id: str, url: str, rate_limit: float | None) -> None:
+    """Execute the full scrape pipeline for a job."""
+    from app.storage.database import async_session
+
+    async with async_session() as session:
+        job = await session.get(ScrapeJob, job_id)
+        if not job:
+            return
+
+        try:
+            # Phase 1: Discovery
+            job.status = JobStatus.DISCOVERING
+            await session.commit()
+
+            discovery = await discover(url)
+
+            if not discovery.pages:
+                job.status = JobStatus.FAILED
+                job.error_message = "No pages discovered"
+                await session.commit()
+                return
+
+            # Map discovery method
+            method_map: dict[str, DiscoveryMethod] = {
+                "llms_txt": DiscoveryMethod.LLMS_TXT,
+                "sitemap": DiscoveryMethod.SITEMAP,
+                "sidebar": DiscoveryMethod.SIDEBAR,
+            }
+            job.discovery_method = method_map.get(discovery.method)
+            job.total_pages = len(discovery.pages)
+
+            # Store discovered URLs
+            for page in discovery.pages:
+                session.add(
+                    DiscoveredUrl(
+                        job_id=job_id,
+                        url=page.url,
+                        source=job.discovery_method or DiscoveryMethod.LLMS_TXT,
+                        title_hint=page.title,
+                        section_hint=page.section,
+                    )
+                )
+            await session.commit()
+
+            # Phase 2: Scrape
+            job.status = JobStatus.SCRAPING
+            await session.commit()
+
+            output_dir = settings.output_dir / job_id
+            job.output_dir = str(output_dir)
+
+            async def on_progress(progress: ScrapeProgress) -> None:
+                """Update job progress in the database."""
+                job.scraped_pages = progress.completed
+                await session.commit()
+                # Also broadcast via WebSocket (imported lazily to avoid circular)
+                from app.api.ws import broadcast
+
+                await broadcast(
+                    job_id,
+                    {
+                        "type": "progress",
+                        "job_id": job_id,
+                        "scraped": progress.completed,
+                        "total": progress.total,
+                        "current_url": progress.current_url,
+                    },
+                )
+
+            fetcher = Fetcher(
+                rate_limit=rate_limit or settings.rate_limit_rps,
+                max_concurrent=settings.max_concurrent,
+                max_retries=settings.max_retries,
+                user_agent=settings.user_agent,
+            )
+
+            scrape_result = await scrape(
+                discovery=discovery,
+                output_dir=output_dir,
+                fetcher=fetcher,
+                progress_callback=on_progress,
+            )
+
+            # Phase 3: Store page results
+            for scraped_page in scrape_result.pages:
+                session.add(
+                    Page(
+                        job_id=job_id,
+                        url=scraped_page.url,
+                        title=scraped_page.title or None,
+                        local_path=scraped_page.local_path,
+                        status=PageStatus.FAILED if scraped_page.error else PageStatus.CONVERTED,
+                        content_hash=scraped_page.content_hash or None,
+                        word_count=scraped_page.word_count,
+                        section=scraped_page.section or None,
+                        scraped_at=datetime.now(UTC),
+                        fetch_time_ms=float(scraped_page.fetch_time_ms),
+                    )
+                )
+
+            job.status = JobStatus.COMPLETE
+            job.scraped_pages = scrape_result.succeeded
+            await session.commit()
+
+            # Broadcast completion
+            from app.api.ws import broadcast
+
+            await broadcast(
+                job_id,
+                {
+                    "type": "complete",
+                    "job_id": job_id,
+                    "status": "complete",
+                    "total_pages": scrape_result.total,
+                    "output_dir": str(output_dir),
+                },
+            )
+
+        except asyncio.CancelledError:
+            job.status = JobStatus.CANCELLED
+            await session.commit()
+        except Exception as e:
+            job.status = JobStatus.FAILED
+            job.error_message = str(e)
+            await session.commit()
+
+            from app.api.ws import broadcast
+
+            # Sanitize: don't leak internal details to WS clients
+            safe_msg = f"Scrape failed: {type(e).__name__}"
+            await broadcast(
+                job_id,
+                {
+                    "type": "error",
+                    "job_id": job_id,
+                    "message": safe_msg,
+                },
+            )
+        finally:
+            _running_tasks.pop(job_id, None)

--- a/backend/app/api/ws.py
+++ b/backend/app/api/ws.py
@@ -1,0 +1,52 @@
+"""WebSocket endpoint for real-time scrape progress."""
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+router = APIRouter(tags=["websocket"])
+
+# Active connections: job_id → set of WebSocket connections
+_connections: dict[str, set[WebSocket]] = {}
+
+
+@router.websocket("/api/ws/{job_id}")
+async def websocket_endpoint(websocket: WebSocket, job_id: str) -> None:
+    """Stream real-time progress events for a scrape job."""
+    await websocket.accept()
+
+    if job_id not in _connections:
+        _connections[job_id] = set()
+    _connections[job_id].add(websocket)
+
+    try:
+        # Keep connection alive — listen for client messages (e.g. pings)
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        pass
+    finally:
+        _connections.get(job_id, set()).discard(websocket)
+        if job_id in _connections and not _connections[job_id]:
+            del _connections[job_id]
+
+
+async def broadcast(job_id: str, message: dict[str, Any]) -> None:
+    """Broadcast a message to all WebSocket clients watching a job."""
+    connections = _connections.get(job_id, set())
+    if not connections:
+        return
+
+    payload = json.dumps(message)
+    dead: list[WebSocket] = []
+
+    for ws in list(connections):  # snapshot to avoid mutation during iteration
+        try:
+            await ws.send_text(payload)
+        except Exception:  # noqa: BLE001
+            dead.append(ws)
+
+    # Clean up disconnected clients
+    for ws in dead:
+        connections.discard(ws)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,9 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.api.browse import router as browse_router
+from app.api.jobs import router as jobs_router
+from app.api.ws import router as ws_router
 from app.config import settings
 from app.models.schemas import HealthResponse
 from app.storage.database import init_db
@@ -33,6 +36,10 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.include_router(jobs_router)
+app.include_router(browse_router)
+app.include_router(ws_router)
 
 
 @app.get("/api/health", response_model=HealthResponse)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -38,6 +38,9 @@ line-length = 100
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP", "B", "A", "SIM", "TCH"]
 
+[tool.ruff.lint.per-file-ignores]
+"app/api/*.py" = ["B008"]  # Depends() in defaults is standard FastAPI DI pattern
+
 [tool.mypy]
 python_version = "3.12"
 strict = true

--- a/backend/tests/test_api/test_browse.py
+++ b/backend/tests/test_api/test_browse.py
@@ -1,0 +1,127 @@
+"""Tests for the browse REST API."""
+
+from pathlib import Path
+
+from httpx import AsyncClient
+
+from app.models.db import JobStatus, ScrapeJob
+from tests.conftest import test_session
+
+
+class TestGetFileTree:
+    """Tests for GET /api/browse/{job_id}/tree."""
+
+    async def test_returns_tree(self, client: AsyncClient, tmp_path: Path) -> None:
+        # Create a job with output directory
+        async with test_session() as session:
+            job = ScrapeJob(url="https://example.com", status=JobStatus.COMPLETE)
+            job.output_dir = str(tmp_path)
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            job_id = job.id
+
+        # Create some files
+        (tmp_path / "guides").mkdir()
+        (tmp_path / "guides" / "quickstart.md").write_text("# Quick Start\n")
+        (tmp_path / "api-reference.md").write_text("# API\n")
+
+        response = await client.get(f"/api/browse/{job_id}/tree")
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should have directory + file at top level
+        names = {n["name"] for n in data}
+        assert "guides" in names
+        assert "api-reference.md" in names
+
+        # Directory should have children
+        guides = next(n for n in data if n["name"] == "guides")
+        assert guides["is_dir"] is True
+        assert len(guides["children"]) == 1
+        assert guides["children"][0]["name"] == "quickstart.md"
+
+    async def test_404_for_missing_job(self, client: AsyncClient) -> None:
+        response = await client.get("/api/browse/nonexistent/tree")
+        assert response.status_code == 404
+
+    async def test_404_when_no_output_dir(self, client: AsyncClient) -> None:
+        async with test_session() as session:
+            job = ScrapeJob(url="https://example.com", status=JobStatus.PENDING)
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            job_id = job.id
+
+        response = await client.get(f"/api/browse/{job_id}/tree")
+        assert response.status_code == 404
+
+    async def test_skips_hidden_files(self, client: AsyncClient, tmp_path: Path) -> None:
+        async with test_session() as session:
+            job = ScrapeJob(url="https://example.com", status=JobStatus.COMPLETE)
+            job.output_dir = str(tmp_path)
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            job_id = job.id
+
+        (tmp_path / ".hidden.md").write_text("hidden")
+        (tmp_path / "_metadata").mkdir()
+        (tmp_path / "visible.md").write_text("visible")
+
+        response = await client.get(f"/api/browse/{job_id}/tree")
+        names = {n["name"] for n in response.json()}
+        assert "visible.md" in names
+        assert ".hidden.md" not in names
+        assert "_metadata" not in names
+
+
+class TestGetFileContent:
+    """Tests for GET /api/browse/{job_id}/file."""
+
+    async def test_returns_content(self, client: AsyncClient, tmp_path: Path) -> None:
+        async with test_session() as session:
+            job = ScrapeJob(url="https://example.com", status=JobStatus.COMPLETE)
+            job.output_dir = str(tmp_path)
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            job_id = job.id
+
+        (tmp_path / "page.md").write_text("# Hello World\n")
+
+        response = await client.get(f"/api/browse/{job_id}/file", params={"path": "page.md"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["content"] == "# Hello World\n"
+        assert data["path"] == "page.md"
+
+    async def test_path_traversal_rejected(self, client: AsyncClient, tmp_path: Path) -> None:
+        async with test_session() as session:
+            job = ScrapeJob(url="https://example.com", status=JobStatus.COMPLETE)
+            job.output_dir = str(tmp_path)
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            job_id = job.id
+
+        response = await client.get(
+            f"/api/browse/{job_id}/file",
+            params={"path": "../../etc/passwd"},
+        )
+        assert response.status_code == 403
+
+    async def test_404_for_missing_file(self, client: AsyncClient, tmp_path: Path) -> None:
+        async with test_session() as session:
+            job = ScrapeJob(url="https://example.com", status=JobStatus.COMPLETE)
+            job.output_dir = str(tmp_path)
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            job_id = job.id
+
+        response = await client.get(
+            f"/api/browse/{job_id}/file",
+            params={"path": "nonexistent.md"},
+        )
+        assert response.status_code == 404

--- a/backend/tests/test_api/test_jobs.py
+++ b/backend/tests/test_api/test_jobs.py
@@ -1,0 +1,101 @@
+"""Tests for the jobs REST API."""
+
+from unittest.mock import AsyncMock, patch
+
+from httpx import AsyncClient
+
+
+class TestCreateJob:
+    """Tests for POST /api/jobs."""
+
+    async def test_creates_job(self, client: AsyncClient) -> None:
+        with patch("app.api.jobs._run_job", new_callable=AsyncMock):
+            response = await client.post(
+                "/api/jobs",
+                json={"url": "https://example.com/docs"},
+            )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["url"] == "https://example.com/docs"
+        assert data["status"] == "pending"
+        assert data["id"]
+
+    async def test_invalid_url_rejected(self, client: AsyncClient) -> None:
+        response = await client.post(
+            "/api/jobs",
+            json={"url": "not-a-url"},
+        )
+        assert response.status_code == 422
+
+
+class TestListJobs:
+    """Tests for GET /api/jobs."""
+
+    async def test_empty_list(self, client: AsyncClient) -> None:
+        response = await client.get("/api/jobs")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    async def test_returns_created_jobs(self, client: AsyncClient) -> None:
+        with patch("app.api.jobs._run_job", new_callable=AsyncMock):
+            await client.post("/api/jobs", json={"url": "https://a.com/docs"})
+            await client.post("/api/jobs", json={"url": "https://b.com/docs"})
+
+        response = await client.get("/api/jobs")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+
+
+class TestGetJob:
+    """Tests for GET /api/jobs/{id}."""
+
+    async def test_returns_job(self, client: AsyncClient) -> None:
+        with patch("app.api.jobs._run_job", new_callable=AsyncMock):
+            create_resp = await client.post("/api/jobs", json={"url": "https://example.com/docs"})
+        job_id = create_resp.json()["id"]
+
+        response = await client.get(f"/api/jobs/{job_id}")
+        assert response.status_code == 200
+        assert response.json()["id"] == job_id
+
+    async def test_404_for_missing_job(self, client: AsyncClient) -> None:
+        response = await client.get("/api/jobs/nonexistent-id")
+        assert response.status_code == 404
+
+
+class TestCancelJob:
+    """Tests for DELETE /api/jobs/{id}."""
+
+    async def test_cancels_pending_job(self, client: AsyncClient) -> None:
+        with patch("app.api.jobs._run_job", new_callable=AsyncMock):
+            create_resp = await client.post("/api/jobs", json={"url": "https://example.com/docs"})
+        job_id = create_resp.json()["id"]
+
+        response = await client.delete(f"/api/jobs/{job_id}")
+        assert response.status_code == 204
+
+        # Verify job is cancelled
+        get_resp = await client.get(f"/api/jobs/{job_id}")
+        assert get_resp.json()["status"] == "cancelled"
+
+    async def test_404_for_missing_job(self, client: AsyncClient) -> None:
+        response = await client.delete("/api/jobs/nonexistent-id")
+        assert response.status_code == 404
+
+
+class TestGetJobPages:
+    """Tests for GET /api/jobs/{id}/pages."""
+
+    async def test_empty_pages(self, client: AsyncClient) -> None:
+        with patch("app.api.jobs._run_job", new_callable=AsyncMock):
+            create_resp = await client.post("/api/jobs", json={"url": "https://example.com/docs"})
+        job_id = create_resp.json()["id"]
+
+        response = await client.get(f"/api/jobs/{job_id}/pages")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    async def test_404_for_missing_job(self, client: AsyncClient) -> None:
+        response = await client.get("/api/jobs/nonexistent-id/pages")
+        assert response.status_code == 404

--- a/backend/tests/test_api/test_ws.py
+++ b/backend/tests/test_api/test_ws.py
@@ -1,0 +1,50 @@
+"""Tests for the WebSocket endpoint."""
+
+import json
+
+from starlette.testclient import TestClient
+
+from app.api.ws import _connections, broadcast
+
+
+class TestWebSocket:
+    """Tests for WS /api/ws/{job_id}."""
+
+    def test_connect_and_disconnect(self) -> None:
+        from app.main import app
+
+        client = TestClient(app)
+        with client.websocket_connect("/api/ws/test-job"):
+            # Connection should be tracked
+            assert "test-job" in _connections
+            assert len(_connections["test-job"]) == 1
+
+        # After disconnect, connection should be cleaned up
+        assert "test-job" not in _connections or len(_connections.get("test-job", set())) == 0
+
+
+class TestBroadcast:
+    """Tests for the broadcast helper."""
+
+    async def test_broadcast_no_connections(self) -> None:
+        """Broadcasting with no connections should not error."""
+        await broadcast("no-such-job", {"type": "progress", "scraped": 1})
+
+    async def test_broadcast_to_connections(self) -> None:
+        """Broadcasting should send to all connected clients for a job."""
+        from app.main import app
+
+        client = TestClient(app)
+        messages: list[dict[str, object]] = []
+
+        with client.websocket_connect("/api/ws/broadcast-test") as ws:
+            # Send a broadcast
+            await broadcast("broadcast-test", {"type": "progress", "scraped": 5, "total": 10})
+
+            # Receive the message
+            data = ws.receive_text()
+            messages.append(json.loads(data))
+
+        assert len(messages) == 1
+        assert messages[0]["type"] == "progress"
+        assert messages[0]["scraped"] == 5


### PR DESCRIPTION
## Summary

- Adds full REST API for scrape job lifecycle: create, list, get details, cancel, and page-level breakdown
- Adds file browsing endpoints: recursive file tree and raw markdown content
- Adds WebSocket endpoint for real-time scrape progress streaming
- Wires all routers into the FastAPI app entry point

## Security Hardening (Code Review)

- Concurrent job limit (10 max active) prevents resource exhaustion
- Sanitized error messages in WS broadcasts — only exception type name, no internal details
- File size limit (10 MB) on content reads prevents OOM
- File tree uses `stat()` for word count estimation instead of reading all files into memory
- Path traversal protection on all file access endpoints
- Connection set snapshot in broadcast loop prevents `RuntimeError` from concurrent mutation

## Test plan

- [x] 94/94 tests pass (`pytest tests/ -x -q`)
- [x] `mypy --strict app/` — zero errors (23 files)
- [x] `ruff check && ruff format --check` — clean
- [x] E2E: All REST endpoints verified (create → list → get → pages → cancel → browse tree → file content → path traversal rejection)
- [x] Code review: All CRITICAL and WARNING issues addressed

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)