### PR TITLE
feat(frontend): WebSocket integration and scraper panel enhancements

### DIFF
--- a/frontend/Cargo.lock
+++ b/frontend/Cargo.lock
@@ -1060,12 +1060,14 @@ version = "0.1.0"
 dependencies = [
  "dioxus",
  "dioxus-logger",
+ "futures-util",
  "gloo-net",
  "gloo-timers",
  "serde",
  "serde_json",
  "tracing",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
 ]
 

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -11,6 +11,20 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 gloo-net = { version = "0.6", features = ["http", "websocket"] }
 gloo-timers = { version = "0.3", features = ["futures"] }
+futures-util = "0.3"
 wasm-bindgen = "0.2"
-web-sys = { version = "0.3", features = ["console"] }
+wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3", features = ["console", "Window", "Location"] }
 tracing = "0.1"
+
+[profile]
+
+[profile.wasm-dev]
+inherits = "dev"
+opt-level = 1
+
+[profile.server-dev]
+inherits = "dev"
+
+[profile.android-dev]
+inherits = "dev"

--- a/frontend/Dioxus.toml
+++ b/frontend/Dioxus.toml
@@ -9,9 +9,8 @@ title = "MiniMax Scraper"
 reload_html = true
 watch_path = ["src", "assets"]
 
-[web.resource]
+[web.resource.dev]
 style = ["assets/main.css"]
 
-[web.proxy]
-# Proxy API requests to the Python backend during development
-"/api" = "http://localhost:8000"
+[[web.proxy]]
+backend = "http://localhost:8000/api"

--- a/frontend/assets/main.css
+++ b/frontend/assets/main.css
@@ -289,6 +289,36 @@ html, body {
 .status-failed { color: var(--text-error); background: rgba(255, 107, 107, 0.15); }
 .status-cancelled { color: var(--text-warn); background: rgba(255, 217, 61, 0.15); }
 
+.scraper-job-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.scraper-cancel-btn {
+    padding: 2px 8px;
+    border: 1px solid var(--text-error);
+    border-radius: var(--radius);
+    background: transparent;
+    color: var(--text-error);
+    font-size: 11px;
+    cursor: pointer;
+    transition: all 0.15s;
+}
+
+.scraper-cancel-btn:hover {
+    background: rgba(255, 107, 107, 0.15);
+}
+
+.scraper-job-error {
+    margin-top: 4px;
+    padding: 4px 8px;
+    font-size: 11px;
+    color: var(--text-error);
+    background: rgba(255, 107, 107, 0.1);
+    border-radius: 4px;
+}
+
 .scraper-job-progress {
     display: flex;
     align-items: center;

--- a/frontend/src/components/scraper.rs
+++ b/frontend/src/components/scraper.rs
@@ -1,8 +1,9 @@
-//! Scraper panel — new job form and job list.
+//! Scraper panel — new job form, real-time progress, and job history.
 
 use dioxus::prelude::*;
 
 use crate::api::client;
+use crate::hooks::use_websocket::use_job_websocket;
 use crate::state::app_state::AppState;
 
 /// Scraper panel with URL input and job management.
@@ -13,7 +14,7 @@ pub fn ScraperPanel() -> Element {
     let mut is_loading = use_signal(|| false);
     let mut error_msg = use_signal(|| None::<String>);
 
-    // Load jobs once on mount — use_hook runs exactly once per component instance
+    // Load jobs once on mount
     use_hook(move || {
         spawn(async move {
             match client::list_jobs().await {
@@ -24,6 +25,10 @@ pub fn ScraperPanel() -> Element {
             }
         });
     });
+
+    // Connect WebSocket for the active job — always called (hook rules)
+    let active_job_id = state.read().active_job_id.clone();
+    use_job_websocket(active_job_id);
 
     let on_submit = move |_| {
         let url = url_input.read().clone();
@@ -84,41 +89,82 @@ pub fn ScraperPanel() -> Element {
                     } else {
                         rsx! {
                             for job in jobs.into_iter() {
-                                {
-                                    let status_class = format!("scraper-job-status status-{}", job.status);
-                                    let progress_style = format!("width: {}%", job.progress_pct);
-                                    let progress_label = format!(
-                                        "{}/{} pages ({}%)",
-                                        job.scraped_pages, job.total_pages, job.progress_pct
-                                    );
-                                    let show_progress = job.total_pages > 0;
-                                    rsx! {
-                                        div {
-                                            class: "scraper-job",
-                                            key: "{job.id}",
-                                            div { class: "scraper-job-header",
-                                                span { class: "scraper-job-url", "{job.url}" }
-                                                span { class: "{status_class}", "{job.status}" }
-                                            }
-                                            if show_progress {
-                                                div { class: "scraper-job-progress",
-                                                    div {
-                                                        class: "progress-bar",
-                                                        div {
-                                                            class: "progress-fill",
-                                                            style: "{progress_style}",
-                                                        }
-                                                    }
-                                                    span { class: "progress-text", "{progress_label}" }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
+                                JobCard { job: job }
                             }
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+/// Individual job card with progress and cancel button.
+#[component]
+fn JobCard(job: crate::api::types::JobResponse) -> Element {
+    let mut state = use_context::<Signal<AppState>>();
+    let status_class = format!("scraper-job-status status-{}", job.status);
+    let is_active = matches!(job.status.as_str(), "pending" | "discovering" | "scraping");
+    let show_progress = job.total_pages > 0;
+    let progress_style = format!("width: {}%", job.progress_pct);
+    let progress_label = format!(
+        "{}/{} pages ({:.0}%)",
+        job.scraped_pages, job.total_pages, job.progress_pct
+    );
+    let job_id = job.id.clone();
+
+    let on_cancel = move |_| {
+        let jid = job_id.clone();
+        spawn(async move {
+            match client::cancel_job(&jid).await {
+                Ok(()) => {
+                    let mut s = state.write();
+                    if let Some(j) = s.jobs.iter_mut().find(|j| j.id == jid) {
+                        j.status = "cancelled".to_string();
+                    }
+                    s.log_messages.push(format!("[INFO] Job {jid} cancelled"));
+                }
+                Err(e) => {
+                    state
+                        .write()
+                        .log_messages
+                        .push(format!("[ERROR] Cancel failed: {e}"));
+                }
+            }
+        });
+    };
+
+    rsx! {
+        div {
+            class: "scraper-job",
+            key: "{job.id}",
+            div { class: "scraper-job-header",
+                span { class: "scraper-job-url", "{job.url}" }
+                div { class: "scraper-job-actions",
+                    span { class: "{status_class}", "{job.status}" }
+                    if is_active {
+                        button {
+                            class: "scraper-cancel-btn",
+                            onclick: on_cancel,
+                            "Cancel"
+                        }
+                    }
+                }
+            }
+            if show_progress {
+                div { class: "scraper-job-progress",
+                    div {
+                        class: "progress-bar",
+                        div {
+                            class: "progress-fill",
+                            style: "{progress_style}",
+                        }
+                    }
+                    span { class: "progress-text", "{progress_label}" }
+                }
+            }
+            if let Some(err) = &job.error_message {
+                div { class: "scraper-job-error", "{err}" }
             }
         }
     }

--- a/frontend/src/hooks/mod.rs
+++ b/frontend/src/hooks/mod.rs
@@ -1,0 +1,1 @@
+pub mod use_websocket;

--- a/frontend/src/hooks/use_websocket.rs
+++ b/frontend/src/hooks/use_websocket.rs
@@ -1,0 +1,200 @@
+//! WebSocket hook for real-time scrape progress updates.
+
+use dioxus::prelude::*;
+use futures_util::StreamExt;
+use gloo_net::websocket::{Message, futures::WebSocket};
+use gloo_timers::future::TimeoutFuture;
+
+use crate::api::types::WsMessage;
+use crate::state::app_state::AppState;
+
+/// Maximum number of log messages to keep in state.
+const MAX_LOG_MESSAGES: usize = 500;
+
+/// Connect a WebSocket to the active job (if any) and dispatch messages to app state.
+/// Always called unconditionally — handles None internally.
+/// Automatically reconnects on disconnect with exponential backoff.
+pub fn use_job_websocket(job_id: Option<String>) {
+    let mut state = use_context::<Signal<AppState>>();
+    let mut current_task = use_signal(|| None::<Task>);
+    let mut connected_job = use_signal(|| None::<String>);
+
+    // When job_id changes, cancel old task and start new one
+    let job_changed = job_id != *connected_job.read();
+
+    if job_changed {
+        // Cancel previous WebSocket task
+        if let Some(task) = current_task.write().take() {
+            task.cancel();
+        }
+        connected_job.set(job_id.clone());
+
+        if let Some(job_id) = job_id {
+            let task = spawn(async move {
+                let mut retry_delay_ms = 1000u32;
+                let max_delay_ms = 16000u32;
+
+                loop {
+                    let ws_url = build_ws_url(&job_id);
+                    push_log(
+                        &mut state,
+                        format!("[INFO] Connecting to WebSocket for job {job_id}..."),
+                    );
+
+                    match WebSocket::open(&ws_url) {
+                        Ok(ws) => {
+                            retry_delay_ms = 1000;
+                            push_log(
+                                &mut state,
+                                format!("[INFO] WebSocket connected for job {job_id}"),
+                            );
+
+                            if let Err(closed) = listen_ws(ws, &job_id, &mut state).await {
+                                push_log(
+                                    &mut state,
+                                    format!("[WARN] WebSocket closed for job {job_id}: {closed}"),
+                                );
+                            }
+
+                            // Check if the job is done — no need to reconnect
+                            let should_reconnect = {
+                                let s = state.read();
+                                s.jobs.iter().any(|j| {
+                                    j.id == job_id
+                                        && !matches!(
+                                            j.status.as_str(),
+                                            "complete" | "failed" | "cancelled"
+                                        )
+                                })
+                            };
+
+                            if !should_reconnect {
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            push_log(
+                                &mut state,
+                                format!("[WARN] WebSocket connection failed: {e}"),
+                            );
+                        }
+                    }
+
+                    push_log(
+                        &mut state,
+                        format!("[INFO] Reconnecting in {retry_delay_ms}ms..."),
+                    );
+                    TimeoutFuture::new(retry_delay_ms).await;
+                    retry_delay_ms = (retry_delay_ms * 2).min(max_delay_ms);
+                }
+            });
+            current_task.set(Some(task));
+        }
+    }
+}
+
+/// Push a log message to state, enforcing the max size cap.
+fn push_log(state: &mut Signal<AppState>, msg: String) {
+    let mut s = state.write();
+    s.log_messages.push(msg);
+    if s.log_messages.len() > MAX_LOG_MESSAGES {
+        let excess = s.log_messages.len() - MAX_LOG_MESSAGES;
+        s.log_messages.drain(0..excess);
+    }
+}
+
+/// Build the WebSocket URL from the current page location.
+fn build_ws_url(job_id: &str) -> String {
+    let window = web_sys::window().expect("no window");
+    let location = window.location();
+    let protocol = location.protocol().unwrap_or_default();
+    let host = location.host().unwrap_or_default();
+    let ws_protocol = if protocol == "https:" { "wss:" } else { "ws:" };
+    format!("{ws_protocol}//{host}/api/ws/{job_id}")
+}
+
+/// Listen for messages on the WebSocket until it closes.
+async fn listen_ws(
+    mut ws: WebSocket,
+    job_id: &str,
+    state: &mut Signal<AppState>,
+) -> Result<(), String> {
+    while let Some(msg_result) = ws.next().await {
+        match msg_result {
+            Ok(Message::Text(text)) => match serde_json::from_str::<WsMessage>(&text) {
+                Ok(ws_msg) => handle_ws_message(ws_msg, job_id, state),
+                Err(e) => {
+                    push_log(state, format!("[WARN] Failed to parse WS message: {e}"));
+                }
+            },
+            Ok(Message::Bytes(_)) => {}
+            Err(e) => {
+                return Err(format!("{e}"));
+            }
+        }
+    }
+
+    Err("connection closed".to_string())
+}
+
+/// Dispatch a parsed WebSocket message to update application state.
+fn handle_ws_message(msg: WsMessage, job_id: &str, state: &mut Signal<AppState>) {
+    match msg.msg_type.as_str() {
+        "progress" => {
+            let scraped = msg.scraped.unwrap_or(0);
+            let total = msg.total.unwrap_or(0);
+            let current_url = msg.current_url.clone().unwrap_or_default();
+
+            let mut s = state.write();
+            if let Some(job) = s.jobs.iter_mut().find(|j| j.id == job_id) {
+                job.scraped_pages = scraped;
+                job.total_pages = total;
+                job.status = "scraping".to_string();
+                if total > 0 {
+                    job.progress_pct = ((scraped as f64 / total as f64) * 100.0).clamp(0.0, 100.0);
+                }
+            }
+            if !current_url.is_empty() {
+                s.log_messages
+                    .push(format!("[INFO] Scraped ({scraped}/{total}): {current_url}"));
+                // Enforce log cap inline for high-frequency progress messages
+                if s.log_messages.len() > MAX_LOG_MESSAGES {
+                    let excess = s.log_messages.len() - MAX_LOG_MESSAGES;
+                    s.log_messages.drain(0..excess);
+                }
+            }
+        }
+        "complete" => {
+            let total = msg.total_pages.unwrap_or(0);
+
+            let mut s = state.write();
+            if let Some(job) = s.jobs.iter_mut().find(|j| j.id == job_id) {
+                job.status = "complete".to_string();
+                job.total_pages = total;
+                job.scraped_pages = total;
+                job.progress_pct = 100.0;
+                job.output_dir = msg.output_dir.clone();
+            }
+            s.log_messages.push(format!(
+                "[INFO] Job {job_id} complete — {total} pages scraped"
+            ));
+        }
+        "error" => {
+            let error_msg = msg
+                .message
+                .clone()
+                .unwrap_or_else(|| "Unknown error".to_string());
+
+            let mut s = state.write();
+            if let Some(job) = s.jobs.iter_mut().find(|j| j.id == job_id) {
+                job.status = "failed".to_string();
+                job.error_message = Some(error_msg.clone());
+            }
+            s.log_messages
+                .push(format!("[ERROR] Job {job_id}: {error_msg}"));
+        }
+        other => {
+            push_log(state, format!("[WARN] Unknown WS message type: {other}"));
+        }
+    }
+}

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -3,6 +3,7 @@
 mod api;
 mod app;
 mod components;
+mod hooks;
 mod state;
 
 fn main() {


### PR DESCRIPTION
## Summary

- **WebSocket hook** (`use_job_websocket`): Connects to backend WS for real-time job progress, with exponential backoff reconnection (1s→16s), automatic task cancellation on job change, and log message cap (500 max)
- **JobCard component**: Displays per-job progress bar, status badge, cancel button for active jobs, and error messages
- **Dioxus.toml fixes**: Corrected `[web.resource.dev]` section and `[[web.proxy]]` array-of-tables syntax for Dioxus 0.6
- **New dependencies**: `futures-util`, `wasm-bindgen-futures`, expanded `web-sys` features

## Key Design Decisions

- Hook always called unconditionally (Dioxus hook rules) with `Option<String>` job ID
- `Task` handle stored in `use_signal` for proper cancellation — prevents leaked background tasks
- `push_log()` helper enforces MAX_LOG_MESSAGES=500 with `drain()` to prevent unbounded memory growth
- `progress_pct` clamped to 0.0–100.0 to prevent overflow display bugs

## Test Plan

- [x] `cargo build --target wasm32-unknown-unknown` — clean
- [x] `cargo clippy --target wasm32-unknown-unknown -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `dx build` — WASM bundles correctly
- [x] Code review: 3 CRITICAL + 5 WARNING issues found and fixed

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)