### PR TITLE
fix(extractor): unescape bold/italic asterisks in table cells

### DIFF
--- a/backend/app/scraper/extractor.py
+++ b/backend/app/scraper/extractor.py
@@ -251,6 +251,12 @@ def _title_from_url(url: str) -> str:
 
 def _clean_markdown(text: str) -> str:
     """Post-process markdown to clean up artifacts."""
+    # Unescape backslash-escaped asterisks that form valid bold/italic patterns.
+    # markdownify over-escapes * inside table cells, producing \*\*text\*\* instead
+    # of **text**.  We restore \*\* pairs first (bold), then lone \* pairs (italic).
+    text = re.sub(r"\\\*\\\*(.+?)\\\*\\\*", r"**\1**", text)
+    text = re.sub(r"\\\*(.+?)\\\*", r"*\1*", text)
+
     # Remove trailing whitespace on each line (must run before blank line collapse)
     text = "\n".join(line.rstrip() for line in text.splitlines())
 

--- a/backend/tests/test_scraper/test_extractor.py
+++ b/backend/tests/test_scraper/test_extractor.py
@@ -89,3 +89,24 @@ class TestExtractContent:
         html = "<html><body><p>Hello</p></body></html>"
         result = extract_content(html, url="https://example.com/page")
         assert result.url == "https://example.com/page"
+
+    def test_unescapes_bold_in_table_cells(self) -> None:
+        html = (
+            "<html><body><article><table><tr>"
+            "<th><strong>Name</strong></th><th><strong>Value</strong></th>"
+            "</tr><tr>"
+            "<td><strong>Bold cell</strong></td><td>Plain</td>"
+            "</tr></table></article></body></html>"
+        )
+        result = extract_content(html)
+        assert "\\*\\*" not in result.markdown
+        assert "**Name**" in result.markdown or "**Bold cell**" in result.markdown
+
+    def test_unescapes_italic_in_table_cells(self) -> None:
+        html = (
+            "<html><body><article><table><tr>"
+            "<td><em>italic text</em></td><td>plain</td>"
+            "</tr></table></article></body></html>"
+        )
+        result = extract_content(html)
+        assert "\\*" not in result.markdown


### PR DESCRIPTION
## Summary
- Fix markdownify over-escaping `*` in table cells (`\*\*text\*\*` → `**text**`)
- Add post-processing regexes in `_clean_markdown()` for bold and italic patterns
- Add 2 tests verifying unescaping in table cells

## Test plan
- [x] 96 tests passing (2 new)
- [x] mypy --strict clean
- [x] ruff clean
- [x] Verified fix against actual MiniMax scrape output

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)