### PR TITLE
feat(ai): add REST API endpoint for AI chat

### DIFF
--- a/backend/app/ai/chat.py
+++ b/backend/app/ai/chat.py
@@ -142,9 +142,7 @@ class CorpusIndex:
                 term_tf = tf[term]
                 idf = self.idf.get(term, 0.0)
                 numerator = term_tf * (k1 + 1)
-                denominator = term_tf + k1 * (
-                    1 - b + b * chunk_len / self.avg_chunk_len
-                )
+                denominator = term_tf + k1 * (1 - b + b * chunk_len / self.avg_chunk_len)
                 score += idf * numerator / denominator
 
             if score > 0:

--- a/backend/app/api/ai.py
+++ b/backend/app/api/ai.py
@@ -1,0 +1,82 @@
+"""REST API endpoints for AI features."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.ai.chat import CorpusIndex, ask
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+from app.ai.client import LLMClient, LLMNotConfiguredError
+from app.models.db import ScrapeJob
+from app.models.schemas import ChatRequest, ChatResponse
+from app.storage.database import get_session
+
+router = APIRouter(prefix="/api/ai", tags=["ai"])
+
+# Cache corpus indexes per job to avoid rebuilding on every request
+_index_cache: dict[str, CorpusIndex] = {}
+
+# Shared LLM client (reused across requests for connection pooling)
+_llm_client: LLMClient | None = None
+
+
+def _get_llm_client() -> LLMClient:
+    """Get or create the shared LLM client."""
+    global _llm_client  # noqa: PLW0603
+    if _llm_client is None:
+        _llm_client = LLMClient()
+    return _llm_client
+
+
+def _get_corpus_index(output_dir: str) -> CorpusIndex:
+    """Get or build a corpus index for the given output directory."""
+    if output_dir not in _index_cache:
+        _index_cache[output_dir] = CorpusIndex.build(Path(output_dir))
+    return _index_cache[output_dir]
+
+
+@router.post("/chat", response_model=ChatResponse)
+async def chat(
+    body: ChatRequest,
+    session: AsyncSession = Depends(get_session),
+) -> Any:
+    """Ask a question about scraped documentation.
+
+    Uses BM25 search to find relevant context, then sends it to MiniMax M2.5
+    for an AI-generated answer with source citations.
+    """
+    job = await session.get(ScrapeJob, body.job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    if not job.output_dir:
+        raise HTTPException(status_code=400, detail="Job has no output directory")
+
+    index = _get_corpus_index(job.output_dir)
+    client = _get_llm_client()
+
+    try:
+        result = await ask(
+            question=body.question,
+            index=index,
+            client=client,
+            top_k=body.top_k,
+        )
+    except LLMNotConfiguredError:
+        raise HTTPException(
+            status_code=503,
+            detail="AI features are not configured. Set MINIMAX_API_KEY.",
+        ) from None
+
+    return ChatResponse(
+        answer=result.answer,
+        sources=result.sources,
+        model=result.model,
+        prompt_tokens=result.prompt_tokens,
+        completion_tokens=result.completion_tokens,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.api.ai import router as ai_router
 from app.api.browse import router as browse_router
 from app.api.jobs import router as jobs_router
 from app.api.ws import router as ws_router
@@ -39,6 +40,7 @@ app.add_middleware(
 
 app.include_router(jobs_router)
 app.include_router(browse_router)
+app.include_router(ai_router)
 app.include_router(ws_router)
 
 

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -82,6 +82,31 @@ class WsMessage(BaseModel):
     output_dir: str | None = None
 
 
+class ChatRequest(BaseModel):
+    """Request to ask a question about scraped documentation."""
+
+    question: str = Field(min_length=1, max_length=2000)
+    job_id: str
+    top_k: int = Field(default=5, ge=1, le=20)
+
+
+class ChatMessageResponse(BaseModel):
+    """A single message in chat history."""
+
+    role: str
+    content: str
+
+
+class ChatResponse(BaseModel):
+    """Response from the AI chat."""
+
+    answer: str
+    sources: list[str]
+    model: str = ""
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+
+
 class HealthResponse(BaseModel):
     """Health check response."""
 

--- a/backend/app/scraper/fetcher.py
+++ b/backend/app/scraper/fetcher.py
@@ -152,9 +152,7 @@ class Fetcher:
         tasks = [self.fetch(url) for url in urls]
         return list(await asyncio.gather(*tasks))
 
-    async def fetch_stream(
-        self, urls: list[str]
-    ) -> collections.abc.AsyncIterator[FetchResult]:
+    async def fetch_stream(self, urls: list[str]) -> collections.abc.AsyncIterator[FetchResult]:
         """Fetch URLs concurrently, yielding results as each completes.
 
         Unlike fetch_many (which blocks until ALL fetches finish), this

--- a/backend/tests/test_ai/test_chat.py
+++ b/backend/tests/test_ai/test_chat.py
@@ -84,9 +84,7 @@ class TestCorpusIndex:
         assert len(index.chunks) == 1
 
     def test_search_returns_relevant_results(self, tmp_path: Path) -> None:
-        (tmp_path / "api.md").write_text(
-            "# REST API\nThe REST API supports JSON requests."
-        )
+        (tmp_path / "api.md").write_text("# REST API\nThe REST API supports JSON requests.")
         (tmp_path / "audio.md").write_text(
             "# Audio\nText to speech synthesis using neural networks."
         )

--- a/backend/tests/test_ai/test_client.py
+++ b/backend/tests/test_ai/test_client.py
@@ -86,9 +86,7 @@ class TestLLMClientComplete:
         client._client = mock_openai
 
         messages = [LLMMessage(role="user", content="Hi")]
-        await client.complete(
-            messages, temperature=0.1, max_tokens=100, model="custom-model"
-        )
+        await client.complete(messages, temperature=0.1, max_tokens=100, model="custom-model")
 
         call_kwargs = mock_openai.chat.completions.create.call_args[1]
         assert call_kwargs["model"] == "custom-model"
@@ -164,9 +162,7 @@ class TestLLMClientStream:
         client._client = mock_openai
 
         collected: list[str] = []
-        async for chunk_text in client.stream(
-            [LLMMessage(role="user", content="Hi")]
-        ):
+        async for chunk_text in client.stream([LLMMessage(role="user", content="Hi")]):
             collected.append(chunk_text)
 
         assert collected == ["Hello", ", ", "world", "!"]

--- a/backend/tests/test_api/test_ai.py
+++ b/backend/tests/test_api/test_ai.py
@@ -1,0 +1,119 @@
+"""Tests for the AI API endpoints."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from httpx import AsyncClient
+
+from app.models.db import JobStatus, ScrapeJob
+
+
+class TestChatEndpoint:
+    """Tests for POST /api/ai/chat."""
+
+    async def test_chat_job_not_found(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            "/api/ai/chat",
+            json={"question": "What is the API?", "job_id": "nonexistent"},
+        )
+        assert resp.status_code == 404
+
+    async def test_chat_job_no_output(self, client: AsyncClient) -> None:
+        import app.storage.database as db_module
+
+        async with db_module.async_session() as session:
+            job = ScrapeJob(url="https://example.com", status=JobStatus.COMPLETE)
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            job_id = job.id
+
+        resp = await client.post(
+            "/api/ai/chat",
+            json={"question": "What is the API?", "job_id": job_id},
+        )
+        assert resp.status_code == 400
+        assert "no output" in resp.json()["detail"].lower()
+
+    async def test_chat_returns_503_when_not_configured(
+        self, client: AsyncClient, tmp_path: Path
+    ) -> None:
+        import app.storage.database as db_module
+
+        async with db_module.async_session() as session:
+            job = ScrapeJob(
+                url="https://example.com",
+                status=JobStatus.COMPLETE,
+                output_dir=str(tmp_path),
+            )
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            job_id = job.id
+
+        # Create a markdown file so the index has content
+        (tmp_path / "doc.md").write_text("# API Reference\nAPI key setup guide.")
+
+        # Clear cache and client to force fresh initialization
+        import app.api.ai as ai_module
+
+        ai_module._index_cache.clear()
+        ai_module._llm_client = None
+
+        resp = await client.post(
+            "/api/ai/chat",
+            json={"question": "API key", "job_id": job_id},
+        )
+        assert resp.status_code == 503
+        assert "MINIMAX_API_KEY" in resp.json()["detail"]
+
+    async def test_chat_success(self, client: AsyncClient, tmp_path: Path) -> None:
+        import app.storage.database as db_module
+
+        async with db_module.async_session() as session:
+            job = ScrapeJob(
+                url="https://example.com",
+                status=JobStatus.COMPLETE,
+                output_dir=str(tmp_path),
+            )
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            job_id = job.id
+
+        (tmp_path / "guide.md").write_text("# Setup Guide\nSet your API key in the config file.")
+
+        import app.api.ai as ai_module
+
+        ai_module._index_cache.clear()
+
+        # Mock the LLM client
+        mock_client = MagicMock()
+        mock_client.complete = AsyncMock(
+            return_value=MagicMock(
+                content="Set the API key in config [guide.md].",
+                model="test-model",
+                prompt_tokens=50,
+                completion_tokens=10,
+            )
+        )
+        ai_module._llm_client = mock_client
+
+        resp = await client.post(
+            "/api/ai/chat",
+            json={"question": "API key config", "job_id": job_id},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "API key" in data["answer"]
+        assert "guide.md" in data["sources"]
+
+        # Cleanup
+        ai_module._llm_client = None
+
+    async def test_chat_validates_question_length(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            "/api/ai/chat",
+            json={"question": "", "job_id": "some-id"},
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

- Adds `POST /api/ai/chat` endpoint that accepts a question + job_id, performs BM25 search over scraped documentation, sends relevant context to MiniMax M2.5, and returns an AI-generated answer with source citations
- Includes `ChatRequest`/`ChatResponse` Pydantic schemas with field validation (question length, top_k bounds)
- Implements corpus index caching per job and shared LLM client with lazy initialization
- Returns 503 with clear message when `MINIMAX_API_KEY` is not configured

## Test plan

- [x] `test_chat_job_not_found` — 404 for nonexistent job
- [x] `test_chat_job_no_output` — 400 for job without output_dir
- [x] `test_chat_returns_503_when_not_configured` — 503 when API key missing
- [x] `test_chat_success` — 200 with mocked LLM client, verifies answer and sources
- [x] `test_chat_validates_question_length` — 422 for empty question
- [x] Full suite: 133 tests pass
- [x] `mypy --strict`: zero issues
- [x] `ruff check + format`: all clean

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)