### PR TITLE
feat(ai): add AI-powered directory structure suggestions

### DIFF
--- a/backend/app/ai/structure.py
+++ b/backend/app/ai/structure.py
@@ -1,0 +1,147 @@
+"""AI-powered directory structure suggestions using MiniMax M2.5."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from app.ai.client import LLMClient, LLMError, LLMMessage
+from app.scraper.organizer import OrganizedPage, organize_pages
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = """\
+You are a documentation structure expert. Given a list of documentation pages \
+(each with a URL, title, and optional section), suggest an optimal directory \
+hierarchy that groups related pages logically.
+
+Rules:
+- Output ONLY valid JSON — no markdown fences, no commentary.
+- The JSON must be an array of objects, each with "url" and "path" keys.
+- Paths should use forward slashes, end in .md, and be lowercase kebab-case.
+- Group related topics into subdirectories (e.g., api-reference/, guides/, etc.).
+- Keep directory depth reasonable (max 3 levels).
+- Every input URL must appear exactly once in the output.
+- Do not invent URLs — only use the ones provided.
+"""
+
+
+def _build_page_list(pages: list[dict[str, str]]) -> str:
+    """Format pages for the LLM prompt."""
+    lines: list[str] = []
+    for i, page in enumerate(pages, 1):
+        url = page.get("url", "")
+        title = page.get("title", "")
+        section = page.get("section", "")
+        parts = [f"{i}. URL: {url}"]
+        if title:
+            parts.append(f"   Title: {title}")
+        if section:
+            parts.append(f"   Section: {section}")
+        lines.append("\n".join(parts))
+    return "\n".join(lines)
+
+
+def _parse_response(content: str, pages: list[dict[str, str]]) -> dict[str, str]:
+    """Parse LLM response into a URL→path mapping.
+
+    Returns an empty dict if the response is invalid or incomplete.
+    """
+    # Strip markdown fences if the LLM wraps in ```json
+    content = content.strip()
+    content = re.sub(r"^```(?:json)?\s*", "", content)
+    content = re.sub(r"\s*```$", "", content)
+
+    try:
+        data: Any = json.loads(content)
+    except json.JSONDecodeError:
+        logger.warning("AI structure response is not valid JSON")
+        return {}
+
+    if not isinstance(data, list):
+        logger.warning("AI structure response is not a JSON array")
+        return {}
+
+    input_urls = {p.get("url", "") for p in pages}
+    mapping: dict[str, str] = {}
+
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        url = item.get("url", "")
+        path = item.get("path", "")
+        if url in input_urls and isinstance(path, str) and path:
+            # Ensure path ends with .md
+            if not path.endswith(".md"):
+                path = path + ".md"
+            # Normalize separators
+            path = path.strip("/")
+            mapping[url] = path
+
+    # Validate completeness — all input URLs must be covered
+    if len(mapping) != len(input_urls):
+        logger.warning(
+            "AI structure response missing URLs: expected %d, got %d",
+            len(input_urls),
+            len(mapping),
+        )
+        return {}
+
+    return mapping
+
+
+async def suggest_structure(
+    pages: list[dict[str, str]],
+    *,
+    client: LLMClient | None = None,
+) -> list[OrganizedPage]:
+    """Use AI to suggest an optimal directory structure for discovered pages.
+
+    Falls back to the heuristic organizer if the AI is unavailable or returns
+    an invalid response.
+
+    Args:
+        pages: List of dicts with 'url', 'title', and optionally 'section'.
+        client: Optional LLM client (creates one if not provided).
+
+    Returns:
+        List of OrganizedPage with AI-suggested or heuristic local_path assignments.
+    """
+    if not pages:
+        return []
+
+    if client is None:
+        client = LLMClient()
+
+    page_list = _build_page_list(pages)
+    messages = [
+        LLMMessage(role="system", content=_SYSTEM_PROMPT),
+        LLMMessage(
+            role="user",
+            content=f"Organize these {len(pages)} documentation pages into a "
+            f"logical directory structure:\n\n{page_list}",
+        ),
+    ]
+
+    try:
+        response = await client.complete(messages, temperature=0.3)
+    except LLMError:
+        logger.info("AI structure suggestion unavailable, using heuristic fallback")
+        return organize_pages(pages)
+
+    mapping = _parse_response(response.content, pages)
+    if not mapping:
+        logger.info("AI structure response invalid, using heuristic fallback")
+        return organize_pages(pages)
+
+    return [
+        OrganizedPage(
+            url=page.get("url", ""),
+            title=page.get("title", ""),
+            local_path=mapping[page["url"]],
+            section=page.get("section", ""),
+        )
+        for page in pages
+    ]

--- a/backend/tests/test_ai/test_structure.py
+++ b/backend/tests/test_ai/test_structure.py
@@ -1,0 +1,216 @@
+"""Tests for the AI directory structure suggestion module."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+from app.ai.client import LLMClient, LLMNotConfiguredError, LLMResponse
+from app.ai.structure import (
+    _build_page_list,
+    _parse_response,
+    suggest_structure,
+)
+
+SAMPLE_PAGES = [
+    {"url": "https://example.com/docs/intro", "title": "Introduction", "section": "Guides"},
+    {"url": "https://example.com/docs/auth", "title": "Authentication", "section": "Guides"},
+    {"url": "https://example.com/docs/api/users", "title": "Users API", "section": "API"},
+    {"url": "https://example.com/docs/api/posts", "title": "Posts API", "section": "API"},
+]
+
+
+class TestBuildPageList:
+    """Tests for _build_page_list()."""
+
+    def test_formats_all_pages(self) -> None:
+        result = _build_page_list(SAMPLE_PAGES)
+        assert "1. URL: https://example.com/docs/intro" in result
+        assert "Title: Introduction" in result
+        assert "Section: Guides" in result
+        assert "4. URL: https://example.com/docs/api/posts" in result
+
+    def test_handles_missing_fields(self) -> None:
+        pages = [{"url": "https://example.com/page"}]
+        result = _build_page_list(pages)
+        assert "1. URL: https://example.com/page" in result
+        assert "Title:" not in result
+        assert "Section:" not in result
+
+    def test_empty_pages(self) -> None:
+        assert _build_page_list([]) == ""
+
+
+class TestParseResponse:
+    """Tests for _parse_response()."""
+
+    def test_parses_valid_json(self) -> None:
+        response = json.dumps(
+            [
+                {"url": "https://example.com/docs/intro", "path": "guides/intro.md"},
+                {"url": "https://example.com/docs/auth", "path": "guides/auth.md"},
+            ]
+        )
+        pages = [
+            {"url": "https://example.com/docs/intro"},
+            {"url": "https://example.com/docs/auth"},
+        ]
+        mapping = _parse_response(response, pages)
+        assert mapping == {
+            "https://example.com/docs/intro": "guides/intro.md",
+            "https://example.com/docs/auth": "guides/auth.md",
+        }
+
+    def test_strips_markdown_fences(self) -> None:
+        response = '```json\n[{"url": "https://a.com/x", "path": "x.md"}]\n```'
+        pages = [{"url": "https://a.com/x"}]
+        mapping = _parse_response(response, pages)
+        assert mapping == {"https://a.com/x": "x.md"}
+
+    def test_adds_md_extension(self) -> None:
+        response = json.dumps([{"url": "https://a.com/x", "path": "guides/x"}])
+        pages = [{"url": "https://a.com/x"}]
+        mapping = _parse_response(response, pages)
+        assert mapping["https://a.com/x"] == "guides/x.md"
+
+    def test_returns_empty_on_invalid_json(self) -> None:
+        assert _parse_response("not json", [{"url": "https://a.com"}]) == {}
+
+    def test_returns_empty_on_non_array(self) -> None:
+        assert _parse_response('{"url": "x"}', [{"url": "x"}]) == {}
+
+    def test_returns_empty_on_missing_urls(self) -> None:
+        response = json.dumps([{"url": "https://a.com/x", "path": "x.md"}])
+        pages = [
+            {"url": "https://a.com/x"},
+            {"url": "https://a.com/y"},  # Not in response
+        ]
+        mapping = _parse_response(response, pages)
+        assert mapping == {}
+
+    def test_ignores_unknown_urls(self) -> None:
+        response = json.dumps(
+            [
+                {"url": "https://a.com/x", "path": "x.md"},
+                {"url": "https://a.com/unknown", "path": "unknown.md"},
+            ]
+        )
+        pages = [{"url": "https://a.com/x"}]
+        mapping = _parse_response(response, pages)
+        assert mapping == {"https://a.com/x": "x.md"}
+
+    def test_strips_leading_slashes(self) -> None:
+        response = json.dumps([{"url": "https://a.com/x", "path": "/guides/x.md"}])
+        pages = [{"url": "https://a.com/x"}]
+        mapping = _parse_response(response, pages)
+        assert mapping["https://a.com/x"] == "guides/x.md"
+
+
+class TestSuggestStructure:
+    """Tests for suggest_structure()."""
+
+    async def test_returns_empty_for_empty_pages(self) -> None:
+        result = await suggest_structure([])
+        assert result == []
+
+    async def test_returns_ai_suggested_paths(self) -> None:
+        ai_response = json.dumps(
+            [
+                {"url": "https://example.com/docs/intro", "path": "guides/intro.md"},
+                {"url": "https://example.com/docs/auth", "path": "guides/auth.md"},
+                {"url": "https://example.com/docs/api/users", "path": "api-reference/users.md"},
+                {"url": "https://example.com/docs/api/posts", "path": "api-reference/posts.md"},
+            ]
+        )
+
+        mock_client = MagicMock(spec=LLMClient)
+        mock_client.complete = AsyncMock(
+            return_value=LLMResponse(content=ai_response, model="test")
+        )
+
+        result = await suggest_structure(SAMPLE_PAGES, client=mock_client)
+
+        assert len(result) == 4
+        assert result[0].local_path == "guides/intro.md"
+        assert result[0].title == "Introduction"
+        assert result[2].local_path == "api-reference/users.md"
+
+    async def test_falls_back_on_llm_error(self) -> None:
+        mock_client = MagicMock(spec=LLMClient)
+        mock_client.complete = AsyncMock(side_effect=LLMNotConfiguredError("No key"))
+
+        result = await suggest_structure(SAMPLE_PAGES, client=mock_client)
+
+        # Should return heuristic results (not empty)
+        assert len(result) == 4
+        # Heuristic organizer uses URL paths
+        assert all(r.local_path.endswith(".md") for r in result)
+
+    async def test_falls_back_on_invalid_response(self) -> None:
+        mock_client = MagicMock(spec=LLMClient)
+        mock_client.complete = AsyncMock(
+            return_value=LLMResponse(content="I can't do that", model="test")
+        )
+
+        result = await suggest_structure(SAMPLE_PAGES, client=mock_client)
+
+        # Should fall back to heuristic
+        assert len(result) == 4
+
+    async def test_falls_back_on_incomplete_response(self) -> None:
+        # Only 2 of 4 URLs in the response
+        partial_response = json.dumps(
+            [
+                {"url": "https://example.com/docs/intro", "path": "guides/intro.md"},
+                {"url": "https://example.com/docs/auth", "path": "guides/auth.md"},
+            ]
+        )
+
+        mock_client = MagicMock(spec=LLMClient)
+        mock_client.complete = AsyncMock(
+            return_value=LLMResponse(content=partial_response, model="test")
+        )
+
+        result = await suggest_structure(SAMPLE_PAGES, client=mock_client)
+
+        # Should fall back to heuristic
+        assert len(result) == 4
+
+    async def test_preserves_section_info(self) -> None:
+        ai_response = json.dumps(
+            [
+                {"url": "https://example.com/docs/intro", "path": "guides/intro.md"},
+                {"url": "https://example.com/docs/auth", "path": "guides/auth.md"},
+                {"url": "https://example.com/docs/api/users", "path": "api/users.md"},
+                {"url": "https://example.com/docs/api/posts", "path": "api/posts.md"},
+            ]
+        )
+
+        mock_client = MagicMock(spec=LLMClient)
+        mock_client.complete = AsyncMock(
+            return_value=LLMResponse(content=ai_response, model="test")
+        )
+
+        result = await suggest_structure(SAMPLE_PAGES, client=mock_client)
+
+        assert result[0].section == "Guides"
+        assert result[2].section == "API"
+
+    async def test_uses_low_temperature(self) -> None:
+        ai_response = json.dumps(
+            [
+                {"url": "https://example.com/docs/intro", "path": "guides/intro.md"},
+                {"url": "https://example.com/docs/auth", "path": "guides/auth.md"},
+                {"url": "https://example.com/docs/api/users", "path": "api/users.md"},
+                {"url": "https://example.com/docs/api/posts", "path": "api/posts.md"},
+            ]
+        )
+
+        mock_client = MagicMock(spec=LLMClient)
+        mock_client.complete = AsyncMock(
+            return_value=LLMResponse(content=ai_response, model="test")
+        )
+
+        await suggest_structure(SAMPLE_PAGES, client=mock_client)
+
+        # Verify temperature=0.3 was passed (deterministic output)
+        call_kwargs = mock_client.complete.call_args[1]
+        assert call_kwargs["temperature"] == 0.3


### PR DESCRIPTION
## Summary

- Adds `suggest_structure()` function that uses MiniMax M2.5 to propose an optimal directory hierarchy from a list of discovered pages
- Gracefully falls back to heuristic `organize_pages()` when AI is unavailable (missing key), API errors, or invalid/incomplete responses
- Parses LLM JSON response with validation: checks all input URLs are covered, strips markdown fences, normalizes paths
- Uses low temperature (0.3) for deterministic structure suggestions

## Test plan

- [x] `test_formats_all_pages` / `test_handles_missing_fields` / `test_empty_pages` — page list formatting
- [x] `test_parses_valid_json` / `test_strips_markdown_fences` / `test_adds_md_extension` — response parsing
- [x] `test_returns_empty_on_invalid_json` / `test_returns_empty_on_non_array` — error handling
- [x] `test_returns_empty_on_missing_urls` / `test_ignores_unknown_urls` — completeness validation
- [x] `test_returns_ai_suggested_paths` — happy path with mocked LLM
- [x] `test_falls_back_on_llm_error` / `test_falls_back_on_invalid_response` / `test_falls_back_on_incomplete_response` — all fallback paths
- [x] `test_preserves_section_info` / `test_uses_low_temperature` — behavior verification
- [x] Full suite: 151 tests pass, mypy --strict clean, ruff clean

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)