### PR TITLE
feat(frontend): add AI Chat panel

### DIFF
--- a/frontend/assets/main.css
+++ b/frontend/assets/main.css
@@ -601,6 +601,164 @@ html, body {
     text-align: center;
 }
 
+/* AI Chat Panel */
+.chat-panel {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.chat-messages {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding-bottom: 8px;
+}
+
+.chat-empty {
+    color: var(--text-secondary);
+    font-size: 13px;
+    font-style: italic;
+    padding: 8px 0;
+}
+
+.chat-bubble {
+    padding: 8px 12px;
+    border-radius: var(--radius);
+    max-width: 85%;
+}
+
+.chat-user {
+    align-self: flex-end;
+    background: var(--accent);
+    color: var(--text-primary);
+}
+
+.chat-assistant {
+    align-self: flex-start;
+    background: var(--bg-input);
+    border: 1px solid var(--border-color);
+    color: var(--text-primary);
+}
+
+.chat-role {
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-secondary);
+    margin-bottom: 4px;
+}
+
+.chat-user .chat-role {
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.chat-content {
+    font-size: 13px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.chat-loading {
+    color: var(--text-secondary);
+    font-style: italic;
+}
+
+.chat-sources {
+    margin-top: 6px;
+    padding-top: 6px;
+    border-top: 1px solid var(--border-color);
+    font-size: 11px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: center;
+}
+
+.chat-sources-label {
+    color: var(--text-secondary);
+    font-weight: 600;
+}
+
+.chat-source-link {
+    color: var(--text-accent);
+    cursor: pointer;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    padding: 1px 6px;
+    background: rgba(83, 216, 251, 0.1);
+    border-radius: 3px;
+    transition: background 0.15s;
+}
+
+.chat-source-link:hover {
+    background: rgba(83, 216, 251, 0.2);
+    text-decoration: underline;
+}
+
+.chat-error {
+    padding: 8px 12px;
+    background: rgba(255, 107, 107, 0.1);
+    border: 1px solid var(--text-error);
+    border-radius: var(--radius);
+    color: var(--text-error);
+    font-size: 12px;
+}
+
+.chat-input-area {
+    display: flex;
+    gap: 8px;
+    padding-top: 8px;
+    border-top: 1px solid var(--border-color);
+    flex-shrink: 0;
+}
+
+.chat-input {
+    flex: 1;
+    padding: 8px 12px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius);
+    color: var(--text-primary);
+    font-size: 13px;
+    outline: none;
+    transition: border-color 0.15s;
+}
+
+.chat-input:focus {
+    border-color: var(--text-accent);
+}
+
+.chat-input:disabled {
+    opacity: 0.5;
+}
+
+.chat-send-btn {
+    padding: 8px 16px;
+    background: var(--accent);
+    border: none;
+    border-radius: var(--radius);
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s;
+    white-space: nowrap;
+}
+
+.chat-send-btn:hover:not(:disabled) {
+    background: var(--accent-hover);
+}
+
+.chat-send-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 /* Scrollbar styling */
 ::-webkit-scrollbar {
     width: 8px;

--- a/frontend/src/api/client.rs
+++ b/frontend/src/api/client.rs
@@ -4,7 +4,9 @@
 use gloo_net::http::Request;
 use web_sys::js_sys;
 
-use super::types::{CreateJobRequest, FileContentResponse, FileTreeNode, JobResponse};
+use super::types::{
+    ChatRequest, ChatResponse, CreateJobRequest, FileContentResponse, FileTreeNode, JobResponse,
+};
 
 const BASE_URL: &str = "/api";
 
@@ -80,6 +82,34 @@ pub async fn get_file_tree(job_id: &str) -> Result<Vec<FileTreeNode>, String> {
 
     if resp.ok() {
         resp.json().await.map_err(|e| format!("Parse error: {e}"))
+    } else {
+        Err(format!("HTTP {}", resp.status()))
+    }
+}
+
+/// Send a question to the AI chat endpoint.
+pub async fn chat(job_id: &str, question: &str) -> Result<ChatResponse, String> {
+    let body = ChatRequest {
+        question: question.to_string(),
+        job_id: job_id.to_string(),
+        top_k: None,
+    };
+
+    let resp = Request::post(&format!("{BASE_URL}/ai/chat"))
+        .json(&body)
+        .map_err(|e| format!("Serialize error: {e}"))?
+        .send()
+        .await
+        .map_err(|e| format!("Network error: {e}"))?;
+
+    if resp.ok() {
+        resp.json().await.map_err(|e| format!("Parse error: {e}"))
+    } else if resp.status() == 503 {
+        Err("AI not configured. Set MINIMAX_API_KEY on the server.".to_string())
+    } else if resp.status() == 404 {
+        Err("Job not found.".to_string())
+    } else if resp.status() == 400 {
+        Err("Job has no scraped output yet.".to_string())
     } else {
         Err(format!("HTTP {}", resp.status()))
     }

--- a/frontend/src/api/types.rs
+++ b/frontend/src/api/types.rs
@@ -44,6 +44,28 @@ pub struct FileContentResponse {
     pub content: String,
 }
 
+/// Request to send a chat message to AI.
+#[derive(Serialize, Clone, Debug)]
+pub struct ChatRequest {
+    pub question: String,
+    pub job_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_k: Option<u32>,
+}
+
+/// Response from the AI chat endpoint.
+#[derive(Deserialize, Clone, Debug)]
+pub struct ChatResponse {
+    pub answer: String,
+    pub sources: Vec<String>,
+    #[serde(default)]
+    pub model: String,
+    #[serde(default)]
+    pub prompt_tokens: u32,
+    #[serde(default)]
+    pub completion_tokens: u32,
+}
+
 /// WebSocket message from the backend.
 #[derive(Deserialize, Clone, Debug)]
 pub struct WsMessage {

--- a/frontend/src/components/ai_chat.rs
+++ b/frontend/src/components/ai_chat.rs
@@ -1,0 +1,187 @@
+//! AI Chat panel — chat-style Q&A over scraped documentation.
+
+use dioxus::prelude::*;
+
+use crate::api::client;
+use crate::state::app_state::AppState;
+
+/// A single message in the chat.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ChatMessage {
+    pub role: String, // "user" or "assistant"
+    pub content: String,
+    pub sources: Vec<String>,
+}
+
+/// AI Chat panel with message history and input.
+#[component]
+pub fn AiChatPanel() -> Element {
+    let mut state = use_context::<Signal<AppState>>();
+    let mut input_text = use_signal(String::new);
+    let mut messages = use_signal(Vec::<ChatMessage>::new);
+    let mut loading = use_signal(|| false);
+    let mut error_msg = use_signal(|| None::<String>);
+
+    let send_message = move |_| {
+        let question = input_text.read().trim().to_string();
+        if question.is_empty() || *loading.read() {
+            return;
+        }
+
+        let job_id = state.read().active_job_id.clone();
+        let Some(job_id) = job_id else {
+            error_msg.set(Some(
+                "No active job selected. Start a scrape first.".to_string(),
+            ));
+            return;
+        };
+
+        // Add user message
+        messages.write().push(ChatMessage {
+            role: "user".to_string(),
+            content: question.clone(),
+            sources: Vec::new(),
+        });
+        input_text.set(String::new());
+        error_msg.set(None);
+        loading.set(true);
+
+        spawn(async move {
+            match client::chat(&job_id, &question).await {
+                Ok(response) => {
+                    messages.write().push(ChatMessage {
+                        role: "assistant".to_string(),
+                        content: response.answer,
+                        sources: response.sources,
+                    });
+                }
+                Err(e) => {
+                    error_msg.set(Some(e));
+                }
+            }
+            loading.set(false);
+        });
+    };
+
+    // Handle Enter key in input
+    let on_keydown = move |evt: KeyboardEvent| {
+        if evt.key() == Key::Enter && !evt.modifiers().contains(Modifiers::SHIFT) {
+            let question = input_text.read().trim().to_string();
+            if question.is_empty() || *loading.read() {
+                return;
+            }
+
+            let job_id = state.read().active_job_id.clone();
+            let Some(job_id) = job_id else {
+                error_msg.set(Some("No active job selected.".to_string()));
+                return;
+            };
+
+            messages.write().push(ChatMessage {
+                role: "user".to_string(),
+                content: question.clone(),
+                sources: Vec::new(),
+            });
+            input_text.set(String::new());
+            error_msg.set(None);
+            loading.set(true);
+
+            spawn(async move {
+                match client::chat(&job_id, &question).await {
+                    Ok(response) => {
+                        messages.write().push(ChatMessage {
+                            role: "assistant".to_string(),
+                            content: response.answer,
+                            sources: response.sources,
+                        });
+                    }
+                    Err(e) => {
+                        error_msg.set(Some(e));
+                    }
+                }
+                loading.set(false);
+            });
+        }
+    };
+
+    rsx! {
+        div { class: "chat-panel",
+            // Message area
+            div { class: "chat-messages",
+                if messages.read().is_empty() && error_msg.read().is_none() {
+                    div { class: "chat-empty",
+                        "Ask a question about the scraped documentation."
+                    }
+                }
+                {
+                    let msgs = messages.read().clone();
+                    rsx! {
+                        for (i, msg) in msgs.iter().enumerate() {
+                            div {
+                                class: if msg.role == "user" { "chat-bubble chat-user" } else { "chat-bubble chat-assistant" },
+                                key: "{i}",
+                                div { class: "chat-role",
+                                    if msg.role == "user" { "You" } else { "AI" }
+                                }
+                                div { class: "chat-content", "{msg.content}" }
+                                if !msg.sources.is_empty() {
+                                    div { class: "chat-sources",
+                                        span { class: "chat-sources-label", "Sources: " }
+                                        {
+                                            let sources = msg.sources.clone();
+                                            rsx! {
+                                                for source in sources.iter() {
+                                                    span {
+                                                        class: "chat-source-link",
+                                                        onclick: {
+                                                            let source = source.clone();
+                                                            move |_| {
+                                                                let mut s = state.write();
+                                                                s.selected_file = Some(source.clone());
+                                                                s.panels.preview = true;
+                                                                s.panels.explorer = true;
+                                                            }
+                                                        },
+                                                        "{source}"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                if *loading.read() {
+                    div { class: "chat-bubble chat-assistant chat-typing",
+                        div { class: "chat-role", "AI" }
+                        div { class: "chat-content chat-loading", "Thinking..." }
+                    }
+                }
+                if let Some(err) = error_msg.read().as_ref() {
+                    div { class: "chat-error", "{err}" }
+                }
+            }
+
+            // Input area
+            div { class: "chat-input-area",
+                input {
+                    class: "chat-input",
+                    r#type: "text",
+                    placeholder: "Ask about the documentation...",
+                    value: "{input_text}",
+                    disabled: *loading.read(),
+                    oninput: move |evt| input_text.set(evt.value()),
+                    onkeydown: on_keydown,
+                }
+                button {
+                    class: "chat-send-btn",
+                    disabled: *loading.read() || input_text.read().trim().is_empty(),
+                    onclick: send_message,
+                    "Send"
+                }
+            }
+        }
+    }
+}

--- a/frontend/src/components/desktop.rs
+++ b/frontend/src/components/desktop.rs
@@ -2,6 +2,7 @@
 
 use dioxus::prelude::*;
 
+use crate::components::ai_chat::AiChatPanel;
 use crate::components::explorer::ExplorerPanel;
 use crate::components::preview::PreviewPanel;
 use crate::components::scraper::ScraperPanel;
@@ -44,6 +45,13 @@ pub fn Desktop() -> Element {
                         title: "Terminal",
                         panel_key: "terminal",
                         TerminalPanel {}
+                    }
+                }
+                if state.read().panels.ai_chat {
+                    Window {
+                        title: "AI Chat",
+                        panel_key: "ai_chat",
+                        AiChatPanel {}
                     }
                 }
             }
@@ -96,6 +104,14 @@ fn Taskbar() -> Element {
                         state.write().panels.preview = !current;
                     },
                     "Preview"
+                }
+                button {
+                    class: if state.read().panels.ai_chat { "taskbar-btn active" } else { "taskbar-btn" },
+                    onclick: move |_| {
+                        let current = state.read().panels.ai_chat;
+                        state.write().panels.ai_chat = !current;
+                    },
+                    "AI Chat"
                 }
             }
             div { class: "taskbar-status",

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -1,3 +1,4 @@
+pub mod ai_chat;
 pub mod desktop;
 pub mod explorer;
 pub mod preview;

--- a/frontend/src/components/window.rs
+++ b/frontend/src/components/window.rs
@@ -24,6 +24,7 @@ pub fn Window(title: String, panel_key: String, children: Element) -> Element {
                                 "explorer" => state.write().panels.explorer = false,
                                 "preview" => state.write().panels.preview = false,
                                 "terminal" => state.write().panels.terminal = false,
+                                "ai_chat" => state.write().panels.ai_chat = false,
                                 _ => {}
                             }
                         },

--- a/frontend/src/state/app_state.rs
+++ b/frontend/src/state/app_state.rs
@@ -9,6 +9,7 @@ pub struct OpenPanels {
     pub explorer: bool,
     pub preview: bool,
     pub terminal: bool,
+    pub ai_chat: bool,
 }
 
 impl Default for OpenPanels {
@@ -18,6 +19,7 @@ impl Default for OpenPanels {
             explorer: false,
             preview: false,
             terminal: true,
+            ai_chat: false,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds a new **AI Chat** window panel to the Dioxus WASM frontend
- Connects to `POST /api/ai/chat` endpoint for RAG-based Q&A over scraped documentation
- Chat-style UI with user/assistant message bubbles, typing indicator, and error states
- Source citations displayed as clickable links that open the explorer + preview panels
- Taskbar toggle button and window close button fully integrated

## Test plan

- [x] `cargo check` — compiles with zero errors
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — properly formatted
- [x] New `ChatRequest`/`ChatResponse` API types match backend schemas
- [x] `chat()` client function handles 503 (unconfigured), 404 (not found), 400 (no output) errors
- [x] `OpenPanels` state extended with `ai_chat` field
- [x] Window close button handles `ai_chat` panel key
- [x] CSS follows existing dark theme patterns with consistent color variables

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)