### PR TITLE
feat(ai): LRU eviction for corpus index cache

### DIFF
--- a/backend/app/api/ai.py
+++ b/backend/app/api/ai.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -18,8 +19,14 @@ from app.storage.database import get_session
 
 router = APIRouter(prefix="/api/ai", tags=["ai"])
 
-# Cache corpus indexes per job to avoid rebuilding on every request
-_index_cache: dict[str, CorpusIndex] = {}
+# Maximum number of corpus indexes to keep in memory.
+# Each index holds all chunks, IDF tables, and term frequencies for a scraped
+# site, so unbounded caching could consume significant memory.
+_MAX_INDEX_CACHE_SIZE = 10
+
+# LRU cache: OrderedDict maintains insertion/access order — most recently
+# used entries are moved to the end, oldest entries are evicted from the front.
+_index_cache: OrderedDict[str, CorpusIndex] = OrderedDict()
 
 # Shared LLM client (reused across requests for connection pooling)
 _llm_client: LLMClient | None = None
@@ -34,10 +41,22 @@ def _get_llm_client() -> LLMClient:
 
 
 def _get_corpus_index(output_dir: str) -> CorpusIndex:
-    """Get or build a corpus index for the given output directory."""
-    if output_dir not in _index_cache:
-        _index_cache[output_dir] = CorpusIndex.build(Path(output_dir))
-    return _index_cache[output_dir]
+    """Get or build a corpus index, with LRU eviction.
+
+    On cache hit, moves the entry to the end (most recently used).
+    On cache miss, builds the index and evicts the oldest entry if at capacity.
+    """
+    if output_dir in _index_cache:
+        _index_cache.move_to_end(output_dir)
+        return _index_cache[output_dir]
+
+    index = CorpusIndex.build(Path(output_dir))
+    _index_cache[output_dir] = index
+
+    while len(_index_cache) > _MAX_INDEX_CACHE_SIZE:
+        _index_cache.popitem(last=False)
+
+    return index
 
 
 @router.post("/chat", response_model=ChatResponse)

--- a/backend/tests/test_api/test_ai.py
+++ b/backend/tests/test_api/test_ai.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from httpx import AsyncClient
 
+from app.api.ai import _MAX_INDEX_CACHE_SIZE, _get_corpus_index, _index_cache
 from app.models.db import JobStatus, ScrapeJob
 
 
@@ -187,3 +188,68 @@ class TestChatEndpoint:
             json={"question": "test", "job_id": "some-id", "top_k": 25},
         )
         assert resp.status_code == 422
+
+
+class TestCorpusIndexCache:
+    """Tests for LRU eviction of corpus index cache."""
+
+    def test_cache_returns_same_index_on_hit(self, tmp_path: Path) -> None:
+        """Cache hit should return the same object without rebuilding."""
+        _index_cache.clear()
+        d = tmp_path / "job-1"
+        d.mkdir()
+        (d / "doc.md").write_text("# Hello")
+
+        idx1 = _get_corpus_index(str(d))
+        idx2 = _get_corpus_index(str(d))
+        assert idx1 is idx2
+
+        _index_cache.clear()
+
+    def test_cache_evicts_oldest_entry(self, tmp_path: Path) -> None:
+        """When cache exceeds max size, the oldest (least recently used) entry is evicted."""
+        _index_cache.clear()
+
+        dirs: list[str] = []
+        for i in range(_MAX_INDEX_CACHE_SIZE + 1):
+            d = tmp_path / f"job-{i}"
+            d.mkdir()
+            (d / "doc.md").write_text(f"# Doc {i}")
+            dirs.append(str(d))
+            _get_corpus_index(str(d))
+
+        # Cache should be at max size, not max + 1
+        assert len(_index_cache) == _MAX_INDEX_CACHE_SIZE
+        # The first entry (job-0) should have been evicted
+        assert dirs[0] not in _index_cache
+        # The last entry should still be present
+        assert dirs[-1] in _index_cache
+
+        _index_cache.clear()
+
+    def test_cache_hit_refreshes_access_order(self, tmp_path: Path) -> None:
+        """Accessing a cached entry should move it to the end (most recent)."""
+        _index_cache.clear()
+
+        dirs: list[str] = []
+        for i in range(_MAX_INDEX_CACHE_SIZE):
+            d = tmp_path / f"job-{i}"
+            d.mkdir()
+            (d / "doc.md").write_text(f"# Doc {i}")
+            dirs.append(str(d))
+            _get_corpus_index(str(d))
+
+        # Access the first entry to refresh it
+        _get_corpus_index(dirs[0])
+
+        # Now add one more — should evict job-1 (the true oldest), not job-0
+        overflow = tmp_path / "job-overflow"
+        overflow.mkdir()
+        (overflow / "doc.md").write_text("# Overflow")
+        _get_corpus_index(str(overflow))
+
+        assert len(_index_cache) == _MAX_INDEX_CACHE_SIZE
+        assert dirs[0] in _index_cache  # was refreshed, should survive
+        assert dirs[1] not in _index_cache  # true oldest, should be evicted
+
+        _index_cache.clear()


### PR DESCRIPTION
## Summary
- Replace unbounded `dict` corpus index cache with `OrderedDict`-based LRU cache (max 10 entries)
- Cache hits move entries to the end (most recently used); oldest entries are evicted when at capacity
- Prevents unbounded memory growth when chatting across many scraped sites
- 3 new tests: cache hit identity, eviction at capacity, access-order refresh (157 total)

Closes #39

## Test plan
- [x] Backend: 157 tests passing (`pytest`)
- [x] Backend: `mypy --strict` clean
- [x] Backend: `ruff check` + `ruff format --check` clean
- [x] `test_cache_returns_same_index_on_hit` — verifies object identity on cache hit
- [x] `test_cache_evicts_oldest_entry` — fills cache to `MAX + 1`, verifies oldest evicted
- [x] `test_cache_hit_refreshes_access_order` — accesses old entry, fills one more, verifies refresh saved it

🤖 Generated with [Claude Code](https://claude.com/claude-code)