### PR TITLE
fix(frontend): CSS loading and version strings

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -18,7 +18,7 @@ class Settings(BaseSettings):
     rate_limit_rps: float = 5.0
     max_concurrent: int = 5
     max_retries: int = 3
-    user_agent: str = "minimax-scraper/0.1.0 (documentation archiver)"
+    user_agent: str = "minimax-scraper/0.2.1 (documentation archiver)"
 
     # AI (MiniMax M2.5 via OpenAI-compatible API)
     minimax_api_key: str = ""

--- a/backend/app/discovery/engine.py
+++ b/backend/app/discovery/engine.py
@@ -48,7 +48,7 @@ async def discover(
         else httpx.AsyncClient(
             timeout=httpx.Timeout(30.0),
             follow_redirects=True,
-            headers={"User-Agent": "minimax-scraper/0.1.0 (documentation archiver)"},
+            headers={"User-Agent": "minimax-scraper/0.2.1 (documentation archiver)"},
         )
     )
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,7 +26,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 app = FastAPI(
     title="minimax-scraper",
     description="Markdown documentation scraper with OS-like browser UI",
-    version="0.1.0",
+    version="0.2.1",
     lifespan=lifespan,
 )
 

--- a/backend/app/scraper/fetcher.py
+++ b/backend/app/scraper/fetcher.py
@@ -76,7 +76,7 @@ class Fetcher:
         rate_limit: float = 5.0,
         max_concurrent: int = 5,
         max_retries: int = 3,
-        user_agent: str = "minimax-scraper/0.1.0",
+        user_agent: str = "minimax-scraper/0.2.1",
         timeout: float = 30.0,
     ) -> None:
         self.rate_limiter = TokenBucket(rate=rate_limit)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "minimax-scraper"
-version = "0.1.0"
+version = "0.2.1"
 description = "Markdown documentation scraper with OS-like browser UI"
 requires-python = ">=3.12"
 license = {text = "MIT"}

--- a/backend/tests/test_api/test_health.py
+++ b/backend/tests/test_api/test_health.py
@@ -9,4 +9,4 @@ async def test_health_check(client: AsyncClient) -> None:
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
-    assert data["version"] == "0.1.0"
+    assert data["version"] == "0.2.1"

--- a/frontend/Cargo.lock
+++ b/frontend/Cargo.lock
@@ -1171,7 +1171,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "minimax-scraper-frontend"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "ammonia",
  "dioxus",

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minimax-scraper-frontend"
-version = "0.1.0"
+version = "0.2.1"
 edition = "2024"
 license = "MIT"
 

--- a/frontend/Dioxus.toml
+++ b/frontend/Dioxus.toml
@@ -1,6 +1,7 @@
 [application]
 name = "minimax-scraper"
 default_platform = "web"
+asset_dir = "assets"
 
 [web.app]
 title = "MiniMax Scraper"

--- a/frontend/src/components/desktop.rs
+++ b/frontend/src/components/desktop.rs
@@ -115,7 +115,7 @@ fn Taskbar() -> Element {
                 }
             }
             div { class: "taskbar-status",
-                "v0.1.0"
+                "v0.2.1"
             }
         }
     }

--- a/frontend/src/state/app_state.rs
+++ b/frontend/src/state/app_state.rs
@@ -53,7 +53,7 @@ impl Default for AppState {
             file_tree: Vec::new(),
             selected_file: None,
             preview_content: None,
-            log_messages: vec!["MiniMax Scraper v0.1.0 ready.".to_string()],
+            log_messages: vec!["MiniMax Scraper v0.2.1 ready.".to_string()],
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fixed frontend CSS not loading by adding `asset_dir = "assets"` to `Dioxus.toml` — without this, `dx serve` returned the SPA fallback HTML for all asset requests
- Bumped version strings from v0.1.0 to v0.2.1 in terminal welcome, taskbar, and Cargo.toml

## Test Plan
- [x] `cargo clippy --target wasm32-unknown-unknown -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `dx serve` starts and serves CSS correctly (verified via `curl` — returns CSS content, not HTML)
- [x] Browser screenshot confirms dark OS theme renders with all panels styled
- [x] Version shows v0.2.1 in taskbar and terminal
- [x] All 5 panels (Scraper, Terminal, Explorer, Preview, AI Chat) render and function

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)