### PR TITLE
feat(discovery): single-page fallback when no strategy finds pages

### DIFF
--- a/backend/app/api/jobs.py
+++ b/backend/app/api/jobs.py
@@ -125,6 +125,9 @@ async def _run_job(job_id: str, url: str, rate_limit: float | None) -> None:
 
             discovery = await discover(url)
 
+            # Defensive guard: discover() should always return at least one page
+            # (the single-page fallback), but keep this in case a future strategy
+            # is added that can return an empty result.
             if not discovery.pages:
                 job.status = JobStatus.FAILED
                 job.error_message = "No pages discovered"
@@ -136,6 +139,7 @@ async def _run_job(job_id: str, url: str, rate_limit: float | None) -> None:
                 "llms_txt": DiscoveryMethod.LLMS_TXT,
                 "sitemap": DiscoveryMethod.SITEMAP,
                 "sidebar": DiscoveryMethod.SIDEBAR,
+                "single_page": DiscoveryMethod.SINGLE_PAGE,
             }
             job.discovery_method = method_map.get(discovery.method)
             job.total_pages = len(discovery.pages)

--- a/backend/app/discovery/engine.py
+++ b/backend/app/discovery/engine.py
@@ -4,6 +4,7 @@ Tries discovery strategies in priority order:
 1. llms.txt (most structured)
 2. sitemap.xml (URL list, less metadata)
 3. Sidebar crawl (last resort, fragile)
+4. Single-page fallback (treats the submitted URL as the only page)
 """
 
 from dataclasses import dataclass, field
@@ -31,7 +32,8 @@ async def discover(
     """Discover all documentation pages on a site.
 
     Tries strategies in priority order: llms.txt → sitemap → sidebar crawl.
-    Returns as soon as one strategy succeeds.
+    Returns as soon as one strategy succeeds. Falls back to treating the
+    submitted URL as a single page if no strategy discovers pages.
 
     Args:
         base_url: Base URL of the documentation site.
@@ -73,7 +75,12 @@ async def discover(
             return result
 
         # Strategy 3: Sidebar crawl (TODO — implement in sidebar.py)
-        # For now, return empty result
+
+        # Fallback: treat the submitted URL itself as a single page to scrape.
+        # This allows users to scrape individual pages without needing the docs root.
+        result.pages = [DiscoveredPage(url=base_url, title="", section="")]
+        result.method = "single_page"
+        return result
 
     finally:
         if own_client:

--- a/backend/app/models/db.py
+++ b/backend/app/models/db.py
@@ -40,6 +40,7 @@ class DiscoveryMethod(enum.StrEnum):
     LLMS_TXT = "llms_txt"
     SITEMAP = "sitemap"
     SIDEBAR = "sidebar"
+    SINGLE_PAGE = "single_page"
 
 
 class ScrapeJob(Base):

--- a/backend/tests/test_discovery/test_engine.py
+++ b/backend/tests/test_discovery/test_engine.py
@@ -63,14 +63,15 @@ class TestDiscover:
         assert result.method == "sitemap"
         assert len(result.pages) == 3  # filtered to /docs
 
-    async def test_returns_empty_when_nothing_found(self) -> None:
-        """When no discovery method works, returns empty result."""
+    async def test_falls_back_to_single_page_when_nothing_found(self) -> None:
+        """When no discovery method works, falls back to single-page scrape."""
         transport = httpx.MockTransport(lambda req: httpx.Response(404))
         async with httpx.AsyncClient(transport=transport) as client:
-            result = await discover("https://example.com", client=client)
+            result = await discover("https://example.com/docs/guide", client=client)
 
-        assert result.method == "none"
-        assert result.pages == []
+        assert result.method == "single_page"
+        assert len(result.pages) == 1
+        assert result.pages[0].url == "https://example.com/docs/guide"
 
     async def test_creates_own_client_if_none(self) -> None:
         """When no client is passed, creates and closes its own."""
@@ -81,8 +82,8 @@ class TestDiscover:
         with patch("app.discovery.engine.httpx.AsyncClient", return_value=mock_client):
             result = await discover("https://example.com", client=None)
 
-        assert result.method == "none"
-        assert result.pages == []
+        assert result.method == "single_page"
+        assert len(result.pages) == 1
 
     async def test_path_filter_passed_to_sitemap(self, sitemap_xml: str) -> None:
         """Custom path_filter is forwarded to sitemap parser."""


### PR DESCRIPTION
## Summary
- When all discovery strategies (llms.txt, sitemap, sidebar) fail, the engine now falls back to treating the submitted URL as a single page to scrape
- Adds `SINGLE_PAGE` to the `DiscoveryMethod` enum and maps it in the job runner
- Users can now scrape individual page URLs without needing a docs root with discoverable index files

## Changes
- `backend/app/discovery/engine.py` — single-page fallback after sidebar crawl strategy, updated docstrings
- `backend/app/models/db.py` — added `SINGLE_PAGE` to `DiscoveryMethod` enum
- `backend/app/api/jobs.py` — added `single_page` to `method_map`, added defensive guard comment
- `backend/tests/test_discovery/test_engine.py` — updated 2 tests to expect `single_page` instead of empty results

## Test plan
- [x] `pytest` — 161 tests pass (zero failures)
- [x] `mypy --strict` — no type errors
- [x] `ruff check && ruff format --check` — all clean
- [x] Code review via subagent — approved with minor suggestions (addressed)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)